### PR TITLE
Add striping for codeblock

### DIFF
--- a/src/components/docs_utils/CodeBlock.jsx
+++ b/src/components/docs_utils/CodeBlock.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus, vs as vscLightPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Copy, Check, Terminal } from 'lucide-react';
@@ -113,6 +113,19 @@ const CodeBlock = ({ code = '', lang = 'no', filename, showTitleCopyButton = (la
         bashLine: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 1rem' },
     };
 
+    // --- NORMALIZE / CLEAN CODE PROP ---
+    const cleanedCode = useMemo(() => {
+        if (typeof code !== 'string') return '';
+        // Normalize CRLF to LF then split
+        const normalized = code.replace(/\r\n/g, '\n');
+        const lines = normalized.split('\n');
+        // If first line is empty (only a newline at start), drop it
+        if (lines.length > 0 && lines[0].trim() === '') {
+            lines.shift();
+        }
+        return lines.join('\n');
+    }, [code]);
+
     // --- RENDER LOGIC FOR BASH SCRIPTS ---
     if (lang === 'bash') {
         const commandOnlyRegex = /^\s*(?:«[^»]+»\s*)?(\$)\s+/;
@@ -197,12 +210,12 @@ const CodeBlock = ({ code = '', lang = 'no', filename, showTitleCopyButton = (la
                     </div>
                     {/* UPDATE: This button is now hidden by default for bash blocks */}
                     {showTitleCopyButton && (
-                        <CopyButton textToCopy={getCommandsToCopy(code)} themeStyles={currentStyles} />
+                        <CopyButton textToCopy={getCommandsToCopy(cleanedCode)} themeStyles={currentStyles} />
                     )}
                 </div>
-                <div style={{ backgroundColor: bashContainerBg, overflowX: 'auto', padding: '1rem 0', width: '100%' }}>
+                    <div style={{ backgroundColor: bashContainerBg, overflowX: 'auto', padding: '1rem 0', width: '100%' }}>
                     <div style={{ display: 'table', width: 'max-content', minWidth: '100%' }}>
-                        {code.split('\n').map((line, index) => <LineRenderer key={index} line={line} />)}
+                        {cleanedCode.split('\n').map((line, index) => <LineRenderer key={index} line={line} />)}
                     </div>
                 </div>
             </div>
@@ -214,12 +227,12 @@ const CodeBlock = ({ code = '', lang = 'no', filename, showTitleCopyButton = (la
         <div style={{ ...baseStyles.container, ...currentStyles.container }}>
             <div style={{ ...baseStyles.header, ...currentStyles.header }}>
                 <span style={{ ...baseStyles.filename, ...currentStyles.filename }}>{filename || lang}</span>
-                {showTitleCopyButton && (
-                    <CopyButton textToCopy={code} themeStyles={currentStyles} />
+                        {showTitleCopyButton && (
+                    <CopyButton textToCopy={cleanedCode} themeStyles={currentStyles} />
                 )}
             </div>
-            <SyntaxHighlighter language={lang === 'no' ? 'text' : lang} style={syntaxTheme} customStyle={baseStyles.syntaxHighlighter} wrapLines={true} wrapLongLines={true}>
-                {code}
+                <SyntaxHighlighter language={lang === 'no' ? 'text' : lang} style={syntaxTheme} customStyle={baseStyles.syntaxHighlighter} wrapLines={true} wrapLongLines={true}>
+                {cleanedCode}
             </SyntaxHighlighter>
         </div>
     );


### PR DESCRIPTION
Codeblock now strip first empty line automatically, for easier replacement the markdown ``` with jsx tags.