### PR TITLE
hide the axios and grid

### DIFF
--- a/src/components/common/StatisticalData/index.js
+++ b/src/components/common/StatisticalData/index.js
@@ -176,17 +176,18 @@ const TopList = ({ data, title }) => {
       })
       .data(barData)
       .transform({ type: 'sortX', reverse: true, by: "y" })
-      .axis('x', { line: false, title: false, label: false, tick: false })
-      .axis('y', { title: false, line: false, tick: false })
+      .axis('x', { line: false, title: false, label: false, tick: false, grid: false })
+      .axis('y', { title: false, line: false, tick: false, grid: false })
       .encode('x', 'action')
       .encode('y', 'logTotal')
       .scale('y', { 
         nice: false,
         padding: 0.6,
         min: 0,
-        max: Math.max(...barData.map(d => d.logTotal)) * 3.5
+        max: Math.max(...barData.map(d => d.logTotal)) * 3.5,
+        tickCount: 0
       })
-      .scale('x', { padding: 0.6 })
+      .scale('x', { padding: 0.6, tickCount: 0 })
       .style('maxWidth', 200)
       .label({ 
         text: 'action', 

--- a/src/components/common/StatisticalData/styles.module.css
+++ b/src/components/common/StatisticalData/styles.module.css
@@ -271,6 +271,19 @@
   min-height: 400px;
 }
 
+/* 隐藏坐标轴数字和刻度 */
+.chart :global(.g2-axis-label),
+.chart :global(.g2-axis-tick),
+.chart :global(.g2-axis-line),
+.chart :global(.g2-axis-title),
+.chart :global(.g2-axis-grid) {
+  display: none !important;
+}
+
+.chart :global(.g2-axis) {
+  display: none !important;
+}
+
 /* 空状态样式 */
 .emptyState {
   display: flex;


### PR DESCRIPTION
There are some unrealistic scales at the bottom of the column chart on the statistics page, which have no practical meaning and need to be hidden.