### PR TITLE
fix staticalDataPage's bug

### DIFF
--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -11,6 +11,7 @@ import ReleaseProvider, { DownloadRuyi } from '@site/src/pages/LatestReleases';
 
 Ruyi 包管理器当前发布了 x86_64、 riscv64 和 aarch64 三种架构的二进制，可以运行 ``uname -m`` 检查系统架构并下载对应的二进制。
 
+
 如果输出为 ``x86_64``：
 
 <DownloadRuyi arch="x86_64" />

--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -4,6 +4,9 @@
   color: #222;
   line-height: 20px;
   /* margin: 0 auto; */
+  position: relative;
+  z-index: 10;
+  isolation: isolate;
 }
 
 .footer__links {


### PR DESCRIPTION
When switching to the data statistics page, the floating QR code in the footer was partially cut off. This PR fixes that bug.