### PR TITLE
Subscribe button on news page

### DIFF
--- a/src/components/community/Subscription/ButtonSubscription.js
+++ b/src/components/community/Subscription/ButtonSubscription.js
@@ -24,8 +24,11 @@ function ButtonSubscription() {
     <form
       onSubmit={onSubmit}
       style={{
-        justifyContent: "left",
         display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+        justifyContent: "flex-start",
+        width: "100%",
       }}
     >
       <input
@@ -33,9 +36,21 @@ function ButtonSubscription() {
         placeholder="Enter your email"
         onChange={(e) => setEmail(e.target.value)}
         className={styles.input}
+        style={{
+          flex: "1 1 auto",
+          minWidth: 0, // allow input to shrink properly in flex container
+        }}
       />
-      <button type="submit" isLoading={loading} className={styles.button}>
-        Subscribe
+      <button
+        type="submit"
+        disabled={loading}
+        className={styles.button}
+        style={{
+          flex: "0 0 auto",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {loading ? "Submitting..." : "Subscribe"}
       </button>
     </form>
   );

--- a/src/components/community/Subscription/styles.module.css
+++ b/src/components/community/Subscription/styles.module.css
@@ -2,13 +2,14 @@
   font-size: 12px;
   background-color: var(--home-button-primary);
   color: var(--home-button-primary-text);
-  margin: 0.6em 0.3em;
+  margin: 0.6em 0;
   padding: 0.6em 1.2em;
   border-radius: 99rem;
   border: none;
   height: 45px;
   font-weight: bold;
   font-size: 17px;
+  box-sizing: border-box;
 }
 
 .input {
@@ -18,13 +19,15 @@
   box-shadow: none;
   outline: none;
   color: inherit;
-  text-indent: 9px;
+  padding-left: 12px;
   height: 45px;
-  margin-right: 10px;
-  min-width: 250px;
-  margin: 0.6em 0.3em;
+  margin: 0.6em 0;
+  min-width: 0; /* allow input to shrink inside flex containers */
   font-size: 17px;
-  text-align: center;
+  text-align: left;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 20vw; /* limit input max width on large screens */
 }
 
 .button:hover {

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -4,6 +4,7 @@ import Card from "../components/news/Card";
 import { translate } from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
+import ButtonSubscription from "@site/src/components/community/Subscription/ButtonSubscription";
 import axios from "axios";
 import React, { useState, useEffect } from "react";
 
@@ -65,6 +66,10 @@ const NewsPage = () => {
               className="flex h-fit min-w-0 flex-1 flex-col gap-4 md:sticky
                 md:top-20"
             >
+              {/* subscription button for news page */}
+              <div className="p-2">
+                <ButtonSubscription />
+              </div>
               <Card
                 items={weeklies}
                 label={translate({


### PR DESCRIPTION
- Add subscribe button on news page.
- Now button automatically resize to the page's size.

## Summary by Sourcery

Add and integrate a responsive subscription form on the news page and refine the button and input styles to handle dynamic layouts and loading states.

New Features:
- Add a Subscribe button on the news page to allow email subscriptions

Enhancements:
- Convert the subscription form to a flex layout with responsive input and button sizing
- Introduce loading state on the subscribe button to disable it and display 'Submitting...' during submission
- Update CSS rules to use box-sizing, adjust margins, padding, and max-width for better responsiveness