### PR TITLE
docs: update English version

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/IDE/cases/milkv-duo-ide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/IDE/cases/milkv-duo-ide.md
@@ -33,39 +33,46 @@
 
 This article uses the application example duo-examples for the milkv-duo development board. Use either of the following methods to obtain the source code:
 
-   ```bash
+```bash
    # Method 1: git clone
    $ git clone https://github.com/milkv-duo/duo-examples.git
 
    # Method 2: ruyi extract command
    $ ruyi extract milkv-duo-examples
-   ```
+```
 
 ### Importing and Setting Project Properties
 
 1. File > New > Project
 
-   ![1735624096763](image//1735624096763.png)
+   ![1735624096763](image/1735624096763.png)
+
 2. Select C/C++ > Makefile Project with Existing Code > Next
 
-   ![1735623999135](image//1735623999135.png)
+   ![1735623999135](image/1735623999135.png)
+
 3. Import the prepared source code:
 
    - Click Browse > Target source code path
+
    - Toolchain for Indexer Settings：Select RISC-V Cross GCC
+
    - Finish
 
-     ![1735624436834](image//1735624436834.png)
+     ![1735624436834](image/1735624436834.png)
+
 4. Project hello-world > Right-click > Properties to configure related properties
 
    1. Configure the toolchain path for the project
 
-      ![1735624925007](image//1735624925007.png)
+      ![1735624925007](image/1735624925007.png)
 
       Select the path where the compiler was installed by ruyi install (default is under ~/.local/share/ruyi/binaries/x86_64/), or the bin directory under the created virtual environment.
+
    2. Set compilation properties
 
-      ![1735625245878](image//1735625245878.png)
+      ![1735625245878](image/1735625245878.png)
+
 5. Edit the Makefile
 
    - The project's built-in Makefile relies on the envsetup.sh script to pre-set environment variables. In the [vendor documentation practice](https://github.com/milkv-duo/duo-examples/blob/main/README-zh.md), we learned that the compiler prefix, compilation options, and linking parameters were pre-set. For convenience, these are written directly into the Makefile. Note that the TOOLCHAIN_PREFIX path needs to be modified as needed.
@@ -77,52 +84,38 @@ This article uses the application example duo-examples for the milkv-duo develop
    - To automate copying the target program to the target device, the Makefile also includes an upload target (this assumes SSH authentication between the PC and the target device; refer to the "SSH Key Configuration" section at the end). Additionally, the relevant directory must be pre-created on the target device (the storage path is customizable, but ensure the scp command path matches the actual environment).
    - You can further modify the Makefile below; this is just a reference.
 
-     ```makefile
-     # Eclipse toolchain settings
-     #TOOLCHAIN_PREFIX := ~/milkv/duo/duo-examples/host-tools/gcc/riscv64-linux-musl-x86_64/bin/riscv64-unknown-linux-musl-
-     TOOLCHAIN_PREFIX := ~/.local/share/ruyi/binaries/x86_64/gnu-milkv-milkv-duo-musl-bin-0.20240731.0+git.67688c7335e7/bin/riscv64-unknown-linux-musl-
+```makefile
+# Eclipse toolchain settings
+#TOOLCHAIN_PREFIX := ~/milkv/duo/duo-examples/host-tools/gcc/riscv64-linux-musl-x86_64/bin/riscv64-unknown-linux-musl-
+TOOLCHAIN_PREFIX := ~/.local/share/ruyi/binaries/x86_64/gnu-milkv-milkv-duo-musl-bin-0.20240731.0+git.67688c7335e7/bin/riscv64-unknown-linux-musl-
 
-     # Compilation options -O3
-     #CFLAGS := -mcpu=c906fdv -march=rv64imafdcv0p7xthead -mcmodel=medany -mabi=lp64d -DNDEBUG -I/home/phebe/milkv/duo/duo-examples/include/system
-     #LDFLAGS := -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -L/home/phebe/milkv/duo/duo-examples/libs/system/musl_riscv64
-     CFLAGS := -mcpu=c906fdv -march=rv64imafdcv0p7xthead -g  #-mcpu=c906fdv -march=rv64imafdcv0p7xthead : One of the two must be set
-     LDFLAGS :=
+CFLAGS := -mcpu=c906fdv -march=rv64imafdcv0p7xthead -g
+LDFLAGS := 
 
-     TARGET=helloworld
+TARGET = helloworld
 
-     ifeq (,$(TOOLCHAIN_PREFIX))
-     $(error TOOLCHAIN_PREFIX is not set)
-     endif
+CC = $(TOOLCHAIN_PREFIX)gcc
 
-     ifeq (,$(CFLAGS))
-     $(error CFLAGS is not set)
-     endif
+SOURCE = $(wildcard *.c)
+OBJS = $(patsubst %.c,%.o,$(SOURCE))
 
-     CC = $(TOOLCHAIN_PREFIX)gcc
+all: $(TARGET)
 
-     SOURCE = $(wildcard *.c)
-     OBJS = $(patsubst %.c,%.o,$(SOURCE))
+$(TARGET): $(OBJS)
+   $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
 
-     # Default target
-     all: $(TARGET)
+%.o: %.c
+   $(CC) $(CFLAGS) -o $@ -c $<
 
-     $(TARGET): $(OBJS)
-        $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+upload: $(TARGET)
+   scp $(TARGET) root@192.168.42.1:/root/target/$(TARGET)
 
-     %.o: %.c
-        $(CC) $(CFLAGS) -o $@ -c $<
+clean:
+   rm -f *.o $(TARGET)
 
-     # Upload target
-     upload: $(TARGET)
-        scp $(TARGET) root@192.168.42.1:/root/target/$(TARGET)
+.PHONY: all clean upload
+```
 
-     .PHONY: clean upload
-     clean:
-        rm -f *.o $(TARGET)
-
-     # Make 'all' target depend on 'upload' to automatically upload after building
-     all: upload
-     ```
 6. Open a Terminal window in the IDE, create an SSH Terminal to log into the target device and perform related operations. If needed, you can also create a Local Terminal window for combined use. This depends on personal preference. Specific steps:
 
    - Window > Show View > Terminal
@@ -175,7 +168,7 @@ Refer to the image below (the image is a screenshot in Debug mode; since the con
 
 - C/C++ Application: Also defaults to the target program name (Search Project to specify)
 
-- Connect: New > SSH
+- Connect：New >  SSH
 
 - Remote Absolute File Path for C/C++ Application: Enter the absolute path of the target program on the RISC-V device (must match the path in the Makefile upload scp command)
 
@@ -187,8 +180,8 @@ Refer to the image below (the image is a screenshot in Debug mode; since the con
 
 Running effect demonstration:
 
-- [Successful remote run with Skip download to target path checked](image/run1.gif)
-- [Error when running without Skip download to target path checked](image/run1.gif)
+- ![Successful remote run with Skip download to target path checked](image/run1.gif)
+- ![Error when running without Skip download to target path checked](image/run1.gif)
 
   > milkv duo img currently does not support sftp: https://github.com/milkv-duo/duo-buildroot-sdk/issues/167. This issue will be resolved when the milkvduo image supports sftp-server.
   >
@@ -231,50 +224,41 @@ int main()
 **Makefile：**
 
 ```makefile
-# Eclipse toolchain settings
-#TOOLCHAIN_PREFIX := ~/milkv/duo/duo-examples/host-tools/gcc/riscv64-linux-musl-x86_64/bin/riscv64-unknown-linux-musl-
+# Toolchain prefix
 TOOLCHAIN_PREFIX := ~/.local/share/ruyi/binaries/x86_64/gnu-milkv-milkv-duo-musl-bin-0.20240731.0+git.67688c7335e7/bin/riscv64-unknown-linux-musl-
 
-# Compilation options -O3   -static
-#CFLAGS := -mcpu=c906fdv -march=rv64imafdcv0p7xthead -mcmodel=medany -mabi=lp64d -DNDEBUG -I~/milkv/duo/duo-examples/include/system
-#LDFLAGS := -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -L/home/phebe/milkv/duo/duo-examples/libs/system/musl_riscv64
-CFLAGS := -march=rv64imafdcv0p7xthead -g
-LDFLAGS :=
+# Compile options
+CFLAGS := -mcpu=c906fdv -march=rv64imafdcv0p7xthead -g
+LDFLAGS := 
 
-TARGET=sumdemo
+# Target filename
+TARGET = sumdemo
 
-ifeq (,$(TOOLCHAIN_PREFIX))
-$(error TOOLCHAIN_PREFIX is not set)
-endif
-
-ifeq (,$(CFLAGS))
-$(error CFLAGS is not set)
-endif
-
+# Compiler
 CC = $(TOOLCHAIN_PREFIX)gcc
-SOURCE = $(wildcard*.c)
-OBJS = $(patsubst%.c,%.o,$(SOURCE))
 
+# Source and object files
+SOURCE = $(wildcard *.c)
+OBJS = $(patsubst %.c,%.o,$(SOURCE))
 
 # Default target
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-   $(CC)$(CFLAGS) -o $@$(OBJS)$(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
 
 %.o: %.c
-   $(CC)$(CFLAGS) -o $@ -c $<
+	$(CC) $(CFLAGS) -o $@ -c $<
 
 # Upload target
 upload: $(TARGET)
-   scp $(TARGET) root@192.168.42.1:/root/target/$(TARGET)
+	scp $(TARGET) root@192.168.42.1:/root/target/$(TARGET)
 
-.PHONY: clean upload
+# Clean
 clean:
-   rm -f *.o $(TARGET)
+	rm -f *.o $(TARGET)
 
-# Make 'all' target depend on 'upload' to automatically upload after building
-all: upload
+.PHONY: all clean upload
 ```
 
 #### Preparing gdbserver
@@ -318,20 +302,20 @@ Steps for remote debugging using GDBServer + GDB commands:
    $ riscv64-unknown-linux-musl-gdb --version
    $ riscv64-unknown-linux-musl-gdb ./sumdemo
 
-   $ target remote 192.168.42.1:2345   # Port number must match the gdbserver side
+   $ target remote 192.168.42.1:2345   #Port number must match the gdbserver side
 
-   $ break sumdemo.c:8                 # Set a breakpoint at line 8
+   $ break sumdemo.c:8                 #Set a breakpoint at line 8
 
    # The following are commonly used; use as needed
-   $ c                                 # Continue, resume program execution until the next breakpoint
-   $ disp result                       # Track a variable, display its value each time it stops
-   $ print result                      # Print the internal variable result
+   $ c                                 #Continue, resume program execution until the next breakpoint
+   $ disp result                       #Track a variable, display its value each time it stops
+   $ print result                      #Print the internal variable result
 
    ```
 
    ![1736326691511](image/1736326691511.png)
 
-   [Local Terminal + SSH Terminal | GDBServer + GDB Debugging Demonstration](image/gdb-terminal-1.gif)
+   ![Local Terminal + SSH Terminal | GDBServer+GDB Debugging Demonstration](image/gdb-terminal-1.gif)
 
 #### C/C++ Remote Application
 
@@ -369,8 +353,8 @@ Refer to the image below to configure the relevant parameters. Key points:
 
 Running effect demonstration:
 
-- [Error when running without Skip download to target path checked](image/gdb-withdownload.gif)
-- [Successful run with Skip download to target path checked](image/gdb-withoutdownload.gif)
+- ![Error when running without Skip download to target path checked](image/gdb-withdownload.gif)
+- ![Successful run with Skip download to target path checked](image/gdb-withoutdownload.gif)
 
 ## Additional Notes
 
@@ -385,7 +369,7 @@ By configuring SSH key-based passwordless login between the host and the Milk-V 
     2. Add the public key to the Milk-V Duo:
 
 ```bash
-$ cat ~/.ssh/milkvduo.pub | ssh root@192.168.42.1 'mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys'
+$ cat ~/.ssh/xxxx.pub | ssh root@192.168.42.1 'mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys'
 ```
 
     3. Verify: `ssh root@192.168.42.1`

--- a/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/index.md
@@ -25,7 +25,8 @@ The ruyi package manager primarily provides the following functionalities.
 | `ruyi install 'gnu-upstream(0.20231118.0)'`                                                  | Install specified version of GNU upstream toolchain.          | Install historical versions by specifying version number.                      |
 | `ruyi install 'gnu-upstream(==0.20231118.0)'`                                                | Install specific version of GNU upstream toolchain.          | Version matching format should be `<op><ver>`.               |
 | `ruyi install --reinstall gnu-upstream`                                                      | Reinstall GNU upstream toolchain.             |                                     |
-| `ruyi extract ruyisdk-demo`                                                                  | Download and unpack ruyisdk-demo source package.      | Unpacks to current directory.                            |
+| `ruyi uninstall gnu-upstream` | Uninstall an installed package. | You can also use `ruyi remove` or `ruyi rm`. |
+| `ruyi extract ruyisdk-demo`                                                                  | Download and unpack ruyisdk-demo source package.      | By default, unpacks into a directory named after the package and version. |
 | `ruyi venv --toolchain gnu-upstream --emulator qemu-user-riscv-upstream generic ./ruyi_venv` | Create virtual environment with toolchain and emulator in specified directory.      | Uses predefined generic configuration.                   |
 | `ruyi version`                                                                               | Display version of ruyi package manager.              |                                     |
 | `ruyi self uninstall`                                                                        | Uninstall ruyi package manager.               | Command will prompt for confirmation.                          |

--- a/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/intergration.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/intergration.mdx
@@ -118,6 +118,7 @@ Obtain the ruyisdk-demo source code:
 
 <CodeBlock lang="bash" showTitleCopyButton="true" code={`
 $ ruyi extract ruyisdk-demo
+$ cd ruyisdk-demo-0.20231114.0
 $ ls
 README.md  rvv-autovec
 `} />

--- a/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/packages.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/packages.mdx
@@ -119,7 +119,7 @@ List of available packages:
 * extra/wps-office
   - 12.1.0-r.17900 (latest)
   - 12.1.0-r.17885 ()
-`} />
+    `} />
 
 The ``list`` command also provides the ``--verbose`` or ``-v`` option to output more detailed information, which will print almost all information from the package repository. Since the full output will be very long, it is recommended to pass a non-empty search field to ``--name-contains``, add other limiting parameters, or redirect the full output to a file or a tool such as ``less``.
 
@@ -210,25 +210,57 @@ The following section clearly contains source packages:
 
 - source: Source packages
 
-Source packages can be downloaded and unpacked into the current directory using the ``extract`` command:
+A source package can be downloaded and extracted using the `extract` command. By default, `extract` will unpack the requested package into a separate directory named after the package and its version.
 
 <CodeBlock lang="bash" showTitleCopyButton="true" code={`
 $ ruyi extract ruyisdk-demo
+$ cd ruyisdk-demo-0.20231114.0
 $ ls
 README.md  rvv-autovec
+`} />
+
+If you need to extract directly into the current working directory (the default behavior in earlier versions), you can use the `--extract-without-subdir` option.
+
+<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+$ ruyi extract --extract-without-subdir ruyisdk-demo
+$ ls
+README.md  rvv-autovec
+`} />
+
+If you need to extract the contents to another directory, you can specify the target directory using the `--dest-dir` or `-d` option.
+
+<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+$ ruyi extract -d /path/to/destination ruyisdk-demo
+`} />
+
+If you only need to download the source package without extracting it, you can use the `--fetch-only` or `-f` option.
+
+<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+$ ruyi extract -f ruyisdk-demo
 `} />
 
 The ``extract`` command supports the same version expression syntax as ``install``.
 
 ## Uninstalling Packages
 
-The Ruyi package manager does not implement the functionality to uninstall specific Ruyi packages. However, you can use the following command to delete all downloaded and installed packages:
+You can use the `ruyi uninstall` command to remove an installed package.
+
+<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+$ ruyi uninstall gnu-upstream
+`} />
+
+This command also has shorter aliases available: `ruyi remove` or `ruyi rm`.
+
+<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+$ ruyi remove gnu-upstream
+$ ruyi rm gnu-upstream
+`} />
+
+If you need to delete all downloaded and installed packages, you can use the following command:
 
 <CodeBlock lang="bash" showTitleCopyButton="true" code={`
 $ ruyi self clean --distfiles --installed-pkgs
 `} />
-
-If you insist on deleting a specific package, although it is not recommended, you can manually delete them. If you accidentally delete some files but Ruyi still considers the package installed, you can try using ``install --reinstall`` to restore it.
 
 Note that if a toolchain package is deleted, any virtual environments that depend on it will become invalid, and there will be no warning when activating such a compilation environment.
 


### PR DESCRIPTION
## Summary by Sourcery

Improve and refine the English documentation by correcting markdown and code formatting, image paths, and command examples, as well as clarifying package manager usage and options.

Documentation:
- Standardize code block fences and Makefile snippets formatting in the IDE guide
- Fix image path references by removing duplicated slashes
- Enhance `ruyi extract` documentation with examples for subdirectory, destination directory, and fetch-only options
- Update package uninstall instructions to use `ruyi uninstall` (with `remove`/`rm` aliases) and adjust the command reference table
- Refine wording, punctuation, and inline command syntax across multiple markdown files for consistency