### PR TITLE
pages: use new about page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
           },
           {
             label: "关于",
-            to: "/contact",
+            to: "/about",
             position: "right",
           },
           {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change the navbar link for the “关于” label to use the new /about page instead of /contact