### PR TITLE
docs: update English version

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/_pythonPip.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Package-Manager/_pythonPip.mdx
@@ -21,6 +21,8 @@ As Python's support for RISC-V continues to improve, we will periodically review
 $ pipx install ruyi
 `} />
 
+In the current version, Ruyi does not fully support virtual environments when installed via `pipx`, so it is recommended to use other installation methods instead.
+
 Once installed, the `ruyi` command will be added to your `PATH`, typically under `~/.local/bin`. You can verify the installation with:
 
 <CodeBlock lang="bash" showTitleCopyButton="true" code={`


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Note that Ruyi currently has incomplete support for virtual environments when installed via pipx and recommend using alternative installation methods.