### PR TITLE
docs(download): add vscode extension download

### DIFF
--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -90,12 +90,16 @@ $ sudo tar -zxvf ruyisdk-0.0.3-linux.gtk."$(uname -m)".tar.gz
 $ /opt/ruyisdk/ruyisdk/ruyisdk
 `} />
 
-除了 IDE 本身，您还需要下载 RuyiSDK IDE 插件。目前插件整合到 RuyiSDK IDE 的工程工作还在完善，当前需要手动将插件拷贝到 RuyiSDK IDE dropins 目录使用，未来我们会完善相关工程，提供更加便捷的安装和使用方式。当前您可以参考下方的使用说明来安装和使用。
+除了 IDE 本身，您还需要下载 RuyiSDK IDE 插件。目前插件整合到 RuyiSDK IDE 的工程工作还在完善，当前需要手动下载插件并安装，未来我们会完善相关工程，提供更加便捷的安装和使用方式。当前您可以参考下方的插件使用说明来安装和使用。
 
 插件使用说明：
 
-+ 从 [GitHub Releases](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/latest) 下载最新插件包
-+ 将 ``org.ruyisdk.ide_*.zip`` 解包到 RuyiSDK IDE 安装目录下的 `dropins` 目录中
++ 从 [GitHub Releases](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/)  或者[RuyiSDK 软件源](https://mirror.isrc.ac.cn/ruyisdk/ide/plugins/eclipse/) 下载最新插件包
++ 参考 [GitHub Releases](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/) 页面中对应版本的安装说明进行安装
+
+### 安装 RuyiSDK VSCode 插件
+
+从 [GitHub Releases](https://github.com/ruyisdk/ruyisdk-vscode-extension/releases) 或者[RuyiSDK 软件源](https://mirror.isrc.ac.cn/ruyisdk/ide/plugins/vscode/) 下载最新 .vsix，在 VS Code 或者 VS Codium 中选择 “从 VSIX 安装”。
 
 ## 开始使用
 


### PR DESCRIPTION
## Summary by Sourcery

Document updated plugin download sources and installation steps, including new guidance for the VSCode extension.

Documentation:
- Update RuyiSDK Eclipse plugin download links to include both GitHub Releases and the RuyiSDK mirror, and reference version-specific installation instructions.
- Add documentation for downloading and installing the RuyiSDK VSCode extension in VS Code and VS Codium.