### PR TITLE
pages: modify some words and i18n

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -397,7 +397,7 @@
   "荔枝派 4A 软件生态已并入 RuyiSDK 项目": {
     "message": "Das Software-Ökosystem von LicheePi 4A ist nun Teil des RuyiSDK-Projekts"
   },
-  "矽速科技（Sipeed）与PLCT实验室联合宣布，RuyiSDK 将作为 LicheePi 4A 开发板的上游支持平台，承担后续的系统维护、升级和软件支持工作。这不仅推动了 RISC-V 开发板的发展与广泛应用，还为开发者提供一个更加便捷高效的开发环境。": {
+  "RuyiSDK 将作为 LicheePi 4A 开发板的上游支持平台，承担后续的系统维护、升级和软件支持工作。这不仅推动了 RISC-V 开发板的发展与广泛应用，还为开发者提供一个更加便捷高效的开发环境。": {
     "message": "Sipeed und das PLCT-Labor haben gemeinsam bekannt gegeben, dass RuyiSDK als Upstream-Support-Plattform für das LicheePi 4A-Entwicklungsboard fungieren wird und künftig für die Systemwartung, Updates und Softwareunterstützung verantwortlich ist. Dies fördert nicht nur die Entwicklung und breite Anwendung von RISC-V-Entwicklungsboards, sondern bietet Entwickler*innen auch eine bequemere und effizientere Entwicklungsumgebung."
   },
   "RISC-V 开发板与操作系统支持矩阵": {

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -419,7 +419,7 @@
   "荔枝派 4A 软件生态已并入 RuyiSDK 项目": {
     "message": "The LicheePi 4A software ecosystem is now integrated into the RuyiSDK project"
   },
-  "矽速科技（Sipeed）与PLCT实验室联合宣布，RuyiSDK 将作为 LicheePi 4A 开发板的上游支持平台，承担后续的系统维护、升级和软件支持工作。这不仅推动了 RISC-V 开发板的发展与广泛应用，还为开发者提供一个更加便捷高效的开发环境。": {
+  "RuyiSDK 将作为 LicheePi 4A 开发板的上游支持平台，承担后续的系统维护、升级和软件支持工作。这不仅推动了 RISC-V 开发板的发展与广泛应用，还为开发者提供一个更加便捷高效的开发环境。": {
     "message": "Sipeed and the PLCT Lab jointly announced that RuyiSDK will serve as the upstream support platform for the LicheePi 4A development board, taking responsibility for future system maintenance, upgrades, and software support. This not only promotes the development and broader adoption of RISC-V development boards but also provides developers with a more convenient and efficient development environment."
   },
   "RISC-V 开发板与操作系统支持矩阵": {

--- a/src/components/common/SlideNews/index.js
+++ b/src/components/common/SlideNews/index.js
@@ -231,7 +231,7 @@ export default function SlideNews() {
     {
       title: <Translate>荔枝派 4A</Translate>,
       subtitle: <Translate>荔枝派 4A 软件生态已并入 RuyiSDK 项目</Translate>,
-      content: "矽速科技（Sipeed）与PLCT实验室联合宣布，RuyiSDK 将作为 LicheePi 4A 开发板的上游支持平台，承担后续的系统维护、升级和软件支持工作。这不仅推动了 RISC-V 开发板的发展与广泛应用，还为开发者提供一个更加便捷高效的开发环境。",
+      content: "RuyiSDK 将作为 LicheePi 4A 开发板的上游支持平台，承担后续的系统维护、升级和软件支持工作。这不仅推动了 RISC-V 开发板的发展与广泛应用，还为开发者提供一个更加便捷高效的开发环境。",
       Image: "img/licheepi-4a.png",
       Links: "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/",
       ButtonText: "立即下载",

--- a/src/pages/about.de.mdx
+++ b/src/pages/about.de.mdx
@@ -21,7 +21,7 @@ import { QRCode, QRGroup } from '@site/src/components/common'
     <li>RISC-V-Paketmanager: <a href="https://github.com/ruyisdk/ruyi" target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:text-sky-700 hover:underline">ruyi</a></li>
     <li>RISC-V-OS-Installationswerkzeug: ruyi device provision</li>
     <li>RISC-V IDE: RuyiSDK IDE</li>
-    <li>RISC-V-Toolchains: PLCT-GCC, PLCT-LLVM</li>
+    <li>RISC-V-Toolchains: RuyiSDK-GCC, RuyiSDK-LLVM</li>
     <li>Wesentliche upstream-Software, die in RuyiSDK integriert ist: QEMU, Box64, LuaJIT, DynamoRIO</li>
   </ul>
 

--- a/src/pages/about.en.mdx
+++ b/src/pages/about.en.mdx
@@ -21,7 +21,7 @@ import { QRCode, QRGroup } from '@site/src/components/common'
     <li>RISC-V package manager: <a href="https://github.com/ruyisdk/ruyi" target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:text-sky-700 hover:underline">ruyi</a></li>
     <li>RISC-V OS installer: **ruyi device provision**</li>
     <li>RISC-V IDE: **RuyiSDK IDE**</li>
-    <li>RISC-V toolchains: **PLCT-GCC, PLCT-LLVM**</li>
+    <li>RISC-V toolchains: **RuyiSDK-GCC, RuyiSDK-LLVM**</li>
     <li>Notable upstream software integrated into RuyiSDK: QEMU, Box64, LuaJIT, DynamoRIO</li>
   </ul>
 

--- a/src/pages/contact.mdx
+++ b/src/pages/contact.mdx
@@ -16,7 +16,7 @@ RUYISDK 由中国科学院软件研究所（ISCAS）主导，旨在为 RISC-V �
 - RISC-V 包管理器：[ruyi](https://github.com/ruyisdk/ruyi)
 - RISC-V 操作系统安装工具：ruyi device provision
 - RISC-V IDE ：RuyiSDK IDE
-- RISC-V 编译工具链：PLCT-GCC、PLCT-LLVM
+- RISC-V 编译工具链：RuyiSDK-GCC、RuyiSDK-LLVM
 - 重点参与 RISC-V 适配和支持的软件（已集成到 RuyiSDK 软件源的部分）：
   - QEMU
   - Box64

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -34,7 +34,7 @@ export default function Footer() {
       items: [
         { label: <Translate id="footer.wechat">微信公众号</Translate>, className: 'hover-wechat-link', to: '/contact' },
         { label: <Translate id="footer.qqgroup">QQ群</Translate>, className: 'hover-qq-link', to: '/contact' },
-        { label: <Translate id="footer.plct">PLCT 实验室</Translate>, href: "https://plctlab.org/" },
+     // { label: <Translate id="footer.plct">PLCT 实验室</Translate>, href: "https://plctlab.org/" },
       ],
     },
     {


### PR DESCRIPTION
## Summary by Sourcery

Update public-facing content to remove PLCT-specific references and adjust branding across pages and footer.

Enhancements:
- Remove the PLCT Lab link from the site footer to align with updated branding and partnerships.

Documentation:
- Update Chinese, English, and German about/contact pages to describe generic GCC/LLVM toolchains instead of PLCT-branded variants.
- Revise LicheePi 4A slide content to remove PLCT lab attribution while keeping RuyiSDK support description.