### PR TITLE
pages(about): fix about page RuyiSDK toolchain

### DIFF
--- a/src/pages/about.zh-Hans.mdx
+++ b/src/pages/about.zh-Hans.mdx
@@ -21,7 +21,7 @@ import { QRCode, QRGroup } from '@site/src/components/common'
     <li>RISC-V 包管理器：<a href="https://github.com/ruyisdk/ruyi" target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:text-sky-700 hover:underline">ruyi</a></li>
     <li>RISC-V 操作系统安装工具：ruyi device provision</li>
     <li>RISC-V IDE：RuyiSDK IDE</li>
-    <li>RISC-V 编译工具链：PLCT-GCC、PLCT-LLVM</li>
+    <li>RISC-V 编译工具链：RuyiSDK-GCC、RuyiSDK-LLVM</li>
     <li>重点参与 RISC-V 适配和支持的软件：QEMU、Box64、LuaJIT、DynamoRIO</li>
   </ul>
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the displayed names of the RISC-V compilation toolchains on the Chinese About page to RuyiSDK-GCC and RuyiSDK-LLVM.