### PR TITLE
ci: fix audo submodule update

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,18 +14,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.4.1
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build website
-        run: pnpm run build
+      - name: PNPM Build
+        uses: ./.github/workflows/composite_npm_build
 
   dco:
     name: DCO compliance

--- a/.github/workflows/composite_npm_build/action.yml
+++ b/.github/workflows/composite_npm_build/action.yml
@@ -1,0 +1,20 @@
+name: PNPM build
+description: Build website with pnpm
+
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 10
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.4.1
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install
+    - name: Build website
+      shell: bash
+      run: pnpm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,18 +16,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.4.1
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build website
-        run: pnpm run build
+      - name: PNPM Build
+        uses: ./.github/workflows/composite_npm_build
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -3,7 +3,7 @@ name: Update Submodules
 on:
   schedule:
     # Run every Thursday at 12:00 PM Beijing Time (04:00 UTC)
-    - cron: '0 4 * * 4' 
+    - cron: '0 4 * * 4'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -12,20 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Token is required for pushing changes
-          token: ${{ secrets.GITHUB_TOKEN }} 
-          # Fetch submodules recursively
-          submodules: recursive 
-      
-      - name: Pull latest changes for all submodules
+          submodules: recursive
+
+      - name: Update submodules
         run: |
-          git submodule update --remote --merge
-          
+          git submodule update --remote --recursive
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update submodules to latest"
+          commit-message: "cron: auto update submodules"
+          signoff: true
           title: "Auto-update: Submodules to latest"
-          body: "This is an automatically generated PR to sync the latest code from all submodules."
-          branch: auto-update-submodules
+          body: "Auto generated PR to sync submodules."
+          branch: create-pull-request/submodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,8 @@
 [submodule "news/weeklies"]
 	path = news/weeklies
 	url = https://github.com/ruyisdk/wechat-articles.git
+	branch = main
 [submodule "news/ruyinews"]
 	path = news/ruyinews
 	url = https://github.com/ruyisdk/packages-index.git
+	branch = main

--- a/scripts/generate-api-latest-pm.cjs
+++ b/scripts/generate-api-latest-pm.cjs
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const API_URL = process.env.RUYI_LATEST_PM_API || 'https://api.ruyisdk.cn/releases/latest-pm';
+const API_URL = 'https://api.ruyisdk.cn/releases/latest-pm';
 const OUT_FILE = path.join(__dirname, '..', 'static', 'data', 'api', 'api_ruyisdk_cn', 'releases_latest_pm.json');
 
 async function main() {


### PR DESCRIPTION
## Summary by Sourcery

Refine CI website build configuration and lock API data generation to the production endpoint while updating tracked news submodules.

Enhancements:
- Hard-code the latest PM API endpoint in the API data generation script to always use the production URL.

CI:
- Replace inline pnpm install/build steps in the check workflow with a shared pnpm_build reusable workflow.

Chores:
- Update git submodule references for news content directories and .gitmodules.