### PR TITLE
ci: submodule update action will create PR

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Allow the update-submodule GitHub Actions workflow to write to pull requests.