### PR TITLE
ci: add automat label for ci audo PR

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -10,6 +10,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
 
     steps:
@@ -29,4 +30,5 @@ jobs:
           signoff: true
           title: "Auto-update: Submodules to latest"
           body: "Auto generated PR to sync submodules."
+          labels: automat
           branch: create-pull-request/submodules


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Grant the update-submodule GitHub Actions workflow write permissions to repository contents and apply an `automat` label to its generated pull requests.