### PR TITLE
ci: check pnpm build after auto submodule update PR

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - create-pull-request/submodules
-      - create-pull-request/data
 
 jobs:
   build:

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -26,9 +26,16 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: |
+            docs
+            news/ruyinews
+            news/weeklies
           commit-message: "cron: auto update submodules"
           signoff: true
           title: "Auto-update: Submodules to latest"
           body: "Auto generated PR to sync submodules."
           labels: automat
           branch: create-pull-request/submodules
+
+      - name: PNPM Build
+        uses: ./.github/workflows/composite_npm_build


### PR DESCRIPTION
## Summary by Sourcery

Restrict submodule auto-update PRs to specific content paths and adjust CI triggers for those branches.

CI:
- Limit created submodule update pull requests to changes in docs and news directories.
- Remove push-based CI checks for the create-pull-request/submodules and create-pull-request/data branches.