### PR TITLE
pages: release /news page

### DIFF
--- a/.github/workflows/update-api-data.yml
+++ b/.github/workflows/update-api-data.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Compute run url
         run: echo "RUN_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Compute run url
         run: echo "RUN_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,24 +79,10 @@ const config = {
             type: "localeDropdown",
             position: "right",
           },
-          { to: "/blog", label: "博客", position: "left" },
-          { to: "/biweekly", label: "双周报", position: "left" },
           { to: "/download", label: "下载", position: "left" },
-          {
-            type: "dropdown",
-            label: "社区",
-            position: "left",
-            items: [
-              {
-                label: "贡献者",
-                to: "/contributors",
-              },
-              {
-                label: "社区守则",
-                to: "/code_of_conduct",
-              },
-            ],
-          },
+          { to: "/news", label: "新闻", position: "left" },
+          { to: "/contributors", label: "贡献者", position: "left" },
+          { href: "https://ruyisdk.cn", label: "社区", position: "left" },
           {
             label: "关于",
             to: "/about",

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -586,11 +586,18 @@
   "贡献者": {
     "message": "Mitwirkende"
   },
+  "新闻": {
+    "message": "Nachrichten"
+  },
   "合作伙伴": {
     "message": "Partner"
   },
   "贡献者公约": {
     "message": "Contributor Covenant"
+  },
+  "footer.社区守则": {
+    "message": "Community-Richtlinien",
+    "description": "Navbar item with label 社区守则"
   },
   "footer.ecosystem": { "message": "Ökosystem" },
   "footer.revyos": { "message": "RevyOS" },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -599,11 +599,18 @@
   "贡献者": {
     "message": "Contributors"
   },
+  "新闻": {
+    "message": "News"
+  },
   "合作伙伴": {
     "message": "Partners"
   },
   "贡献者公约": {
     "message": "Contributor Covenant"
+  },
+  "footer.社区守则": {
+    "message": "Community Code",
+    "description": "Navbar item with label 社区守则"
   },
   "footer.ecosystem": { "message": "Ecosystem" },
   "footer.ruyisdk": { "message": "RuyiSDK" },

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -26,7 +26,7 @@ export default function Footer() {
         { label: <Translate id="footer.riscv-community">RISC-V 开发者社区</Translate>, href: "https://ruyisdk.cn" },
         { label: <Translate id="footer.discussion">讨论组</Translate>, href: "https://github.com/ruyisdk/ruyisdk/discussions" },
         { label: <Translate id="footer.stats">数据统计</Translate>, to: "/dashboard" },
-        { label: <Translate id="footer.intern">实习生招聘</Translate>, href: "https://github.com/plctlab/weloveinterns/blob/master/open-internships.md" },
+        { label: <Translate id="footer.社区守则">社区守则</Translate>, to: "/code_of_conduct" },
       ],
     },
     {
@@ -35,6 +35,7 @@ export default function Footer() {
         { label: <Translate id="footer.wechat">微信公众号</Translate>, className: 'hover-wechat-link', to: '/about' },
         { label: <Translate id="footer.qqgroup">QQ群</Translate>, className: 'hover-qq-link', to: '/about' },
      // { label: <Translate id="footer.plct">PLCT 实验室</Translate>, href: "https://plctlab.org/" },
+        { label: <Translate id="footer.intern">实习生招聘</Translate>, href: "https://github.com/plctlab/weloveinterns/blob/master/open-internships.md" },
       ],
     },
     {


### PR DESCRIPTION
## Summary by Sourcery

Update site navigation to introduce a /news page and adjust community links, while refreshing footer links and bumping GitHub Actions checkout to v4.

New Features:
- Add a top-level /news navigation item to the main site menu.

Enhancements:
- Reorganize main navigation to surface contributors and external community site as primary links instead of a nested community dropdown.
- Adjust footer columns so community guidelines and intern recruitment links are more discoverable.

CI:
- Upgrade GitHub Actions workflows to use actions/checkout@v4.