### PR TITLE
ci: rename branch name for update-api-data

### DIFF
--- a/.github/workflows/update-api-data.yml
+++ b/.github/workflows/update-api-data.yml
@@ -49,7 +49,7 @@ jobs:
             
             **Action run:** ${{ env.RUN_URL }}
           labels: automat
-          branch: create-pull-request/submodules
+          branch: create-pull-request/apiupdate
 
       - name: PNPM Build
         uses: ./.github/workflows/composite_npm_build


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change the target branch name used by the update-api-data workflow when creating automated pull requests.