### PR TITLE
misc: remove /blog /biweekly route from sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,6 +69,12 @@ const config = {
           showReadingTime: true,
           blogDescription: "Blog",
         },
+        sitemap: {
+          ignorePatterns: [
+            '/blog/**',
+            '/biweekly/**'
+          ]
+        },
         theme: {
           customCss: ["./src/css/tailwind.css", "./src/css/custom.scss"],
         },


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add sitemap configuration to ignore /blog and /biweekly routes.