### PR TITLE
ci: skip 403 api error

### DIFF
--- a/scripts/generate-api-github.cjs
+++ b/scripts/generate-api-github.cjs
@@ -133,6 +133,12 @@ async function fetchContributorsWait(repos) {
         continue;
       }
 
+      if (raw.code === 403) {
+        // skip
+        console.info(`[generate-api-github] Skip ${repo} due to 403 ${JSON.stringify(raw)}`);
+        continue;
+      }
+
       if (raw.code === 202) {
         // wait and retry
         console.info(`[generate-api-github] Will retry ${repo}`);


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the API generation script to detect 403 responses and skip processing those repositories with a log message.