### PR TITLE
pages(index): add cas-public-science-day-2026 to news

### DIFF
--- a/news/articles/2026-05-13-cas-public-science-day-2026.en.md
+++ b/news/articles/2026-05-13-cas-public-science-day-2026.en.md
@@ -1,0 +1,9 @@
+---
+date: 2026-05-13
+link: /en/news/events/202605-cas-public-science-day-2026
+image: /img/news/events/202605_cas_public_science_day_2026/title.jpg
+---
+
+# RuyiSDK at the 2026 ISCAS “Software Defines the Future” Public Science Day
+
+On May 16, the Institute of Software, Chinese Academy of Sciences will host its 2026 “Software Defines the Future” Public Science Day at the Zhongguancun Software Park campus in Beijing. As an important contributor to the RISC-V software ecosystem, RuyiSDK will present its complete toolchain, operating system support, and developer resources, and will exchange ideas with developers, open source enthusiasts, university faculty, and students.

--- a/news/articles/2026-05-13-cas-public-science-day-2026.md
+++ b/news/articles/2026-05-13-cas-public-science-day-2026.md
@@ -1,0 +1,9 @@
+---
+date: 2026-05-13
+link: /news/events/202605-cas-public-science-day-2026
+image: /img/news/events/202605_cas_public_science_day_2026/title.jpg
+---
+
+# RuyiSDK亮相中科院软件所2026年“软件定义未来”公众科学日
+
+5月16日，中国科学院软件研究所2026年“软件定义未来”公众科学日将在北京中关村软件园区举行。作为RISC-V软件生态的重要建设者，RuyiSDK携完整工具链、操作系统及开发者资源亮相本届活动，与广大开发者、开源爱好者及高校师生展开技术交流。


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add English and Chinese news entries for the 2026 ISCAS “Software Defines the Future” Public Science Day featuring RuyiSDK.