### PR TITLE
pages(news): add news page title

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -184,6 +184,21 @@
     "message": "Data updated at"
   },
 
+  "========== news ==========": { "message": "" },
+
+  "news.title": {
+    "message": "News"
+  },
+  "news.subtitle": {
+    "message": "See important news from the RuyiSDK team at any time"
+  },
+  "news.biweekly": {
+    "message": "Biweekly"
+  },
+  "news.news": {
+    "message": "Ruyi News"
+  },
+
   "meetup": {
     "message": "Our recent events"
   },
@@ -694,9 +709,6 @@
   "博客": {
     "message": "Blog"
   },
-  "随时看到来自 RuyiSDK 团队的重大消息": {
-    "message": "See important news from the RuyiSDK team at any time"
-  },
   "RuyiSDK · 为 100 万 RISC-V 软件开发人员做好准备": {
     "message": "RuyiSDK: Preparing for 1 Million RISC-V Software Developers"
   },
@@ -807,12 +819,6 @@
   },
   "no.data": {
     "message": "No statistical data available currently."
-  },
-  "news.biweekly": {
-    "message": "Biweekly"
-  },
-  "news.news": {
-    "message": "RuyiSDK News"
   },
 
   "downloads.meta.title": {

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -48,12 +48,6 @@
   "downloads": { "message": "组件下载数量" },
   "installs": { "message": "安装台数" },
   "no.data": { "message": "当前暂无统计数据。" },
-  "news.biweekly": {
-    "message": "双周报"
-  },
-  "news.news": {
-    "message": "RuyiSDK 新闻"
-  },
   "downloads.meta.title": {
     "message": "下载"
   },

--- a/src/pages/news.jsx
+++ b/src/pages/news.jsx
@@ -1,4 +1,4 @@
-import { translate } from "@docusaurus/Translate";
+import Translate, { translate } from "@docusaurus/Translate";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import Layout from "@theme/Layout";
 import React, { useState, useEffect } from "react";
@@ -61,6 +61,14 @@ const NewsPage = () => {
             <div className="flex min-h-0 flex-1 flex-col gap-6 md:flex-row md:gap-x-8 md:gap-y-6">
               {/* left */}
                 <div className="min-w-0 flex-1 md:flex-[3] md:pr-0 lg:pr-0">
+                <div className="mb-6 flex min-h-[57px] items-end gap-4">
+                  <h1 className="m-0 text-3xl font-bold leading-none text-gray-900 md:text-[2rem]">
+                    <Translate id="news.title">新闻</Translate>
+                  </h1>
+                  <p className="m-0 text-[1.05rem] font-medium leading-6 text-gray-600">
+                    <Translate id="news.subtitle">随时看到来自 RuyiSDK 团队的重大消息</Translate>
+                  </p>
+                </div>
                 <Articles items={articles} loading={loading} onClick={handleClick} />
               </div>
 
@@ -73,7 +81,7 @@ const NewsPage = () => {
                   <div className="space-y-4">
                     <Card
                       items={weeklies}
-                      label={translate({ id: "news.biweekly", message: "Biweekly" })}
+                      label={translate({ id: "news.biweekly", message: "双周报" })}
                       color="bg-[var(--ruyi-logo-blue)]"
                       borderColor="border-[var(--ruyi-logo-blue)]"
                       onClick={handleClick}
@@ -81,7 +89,7 @@ const NewsPage = () => {
                     />
                     <Card
                       items={ruyinews}
-                      label={translate({ id: "news.news", message: "RuyiSDK 新闻" })}
+                      label={translate({ id: "news.news", message: "Ruyi 新闻" })}
                       color="bg-[var(--ruyi-logo-yellow)]"
                       borderColor="border-[var(--ruyi-logo-yellow)]"
                       onClick={handleClick}


### PR DESCRIPTION
## Summary by Sourcery

Add a localized title section to the news page and adjust sidebar card labels to updated Chinese copy.

New Features:
- Introduce a header block with localized title and subtitle on the news page.

Enhancements:
- Update biweekly and news card labels with new Chinese wording on the news sidebar.