### PR TITLE
docs: fix code block rendering in VS Code case1

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/VSCode-Plugins/cases/case1.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/VSCode-Plugins/cases/case1.md
@@ -19,15 +19,15 @@ This example uses CoreMark to demonstrate the basic workflow of completing toolc
 5. Configure the build settings in the CoreMark source (refer to the CoreMark repository README):
 
    ```bash input="2"
-# Modify gcc according to CoreMark build instructions
-$ sed -i 's/\bgcc\b/riscv64-plctxthead-linux-gnu-gcc/g' linux64/core_portme.mak
+   # Modify gcc according to CoreMark build instructions
+   $ sed -i 's/\bgcc\b/riscv64-plctxthead-linux-gnu-gcc/g' linux64/core_portme.mak
    ```
 
 6. Open the VS Code terminal (with PATH inherited from the activated environment), navigate to the `coremark` directory, and run the build:
 
    ```bash input="2"
-# Cross-compile and build to generate the executable coremark.exe
-make PORT_DIR=linux64 link
+   # Cross-compile and build to generate the executable coremark.exe
+   make PORT_DIR=linux64 link
    ```
 
 7. Transfer the generated executable to the LicheePi 4A and run it (using `scp`, serial, NFS, etc.).


### PR DESCRIPTION
## Summary

- Fixed broken Markdown formatting in the English VS Code plugin case1 document.
- Indented the bash command lines under steps 5 and 6.
- Ensured the ordered list continues correctly to step 7.

## Test

- Checked the Markdown preview for the affected section.

## Summary by Sourcery

Documentation:
- Fix indentation of bash code blocks in the VS Code plugin case1 English documentation so they appear properly nested under steps 5 and 6.