### PR TITLE
pages(index): better DevBoards components Mobile layout

### DIFF
--- a/src/components/Home/DevBoards/styles.module.css
+++ b/src/components/Home/DevBoards/styles.module.css
@@ -192,6 +192,25 @@
     --devboards-padding: 1rem;
   }
 
+  .copy {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .copy h2 {
+    font-size: 1.5rem;
+    line-height: 1.25;
+  }
+
+  .examplesHeader h3 {
+    font-size: 1.2rem;
+    line-height: 1.25;
+  }
+
+  .copy :global(.primary-button) {
+    margin-bottom: 2rem;
+  }
+
   .boardGrid {
     grid-template-columns: 1fr;
   }
@@ -199,6 +218,14 @@
   .boardCard h3,
   .boardCard p {
     padding-inline: 1rem;
+  }
+
+  .boardCard h3 {
+    font-size: 1.5rem;
+  }
+
+  .boardCard p {
+    font-size: 1.05rem;
   }
 
   .cardLink {


### PR DESCRIPTION
## Summary by Sourcery

Improve the DevBoards mobile layout and typography for better readability and spacing.

Enhancements:
- Adjust text alignment and heading sizes for DevBoards copy and example headers on small screens.
- Refine board card heading and paragraph font sizes for improved readability on mobile.
- Add spacing below the primary button in the DevBoards copy section to enhance mobile layout.