### PR TITLE
ci: wait longer on github api data update

### DIFF
--- a/scripts/generate-api-github.cjs
+++ b/scripts/generate-api-github.cjs
@@ -150,13 +150,13 @@ async function fetchContributorsWait(repos) {
     }
 
     try_time += 1;
-    if (try_time >= 2) {
-      console.warn(`[generate-api-github] Wait more than 10min`)
+    if (try_time > 5) {
+      console.warn(`[generate-api-github] Wait more than 20min`)
       break;
     }
 
-    console.info(`[generate-api-github] Sleep wait 5min`)
-    await sleep(5000 * 60); // 5 min
+    console.info(`[generate-api-github] Sleep wait 4.2min`)
+    await sleep(4200 * 60); // 5 min
   }
 }
 

--- a/src/components/Home/DevBoards/styles.module.css
+++ b/src/components/Home/DevBoards/styles.module.css
@@ -193,7 +193,9 @@
   }
 
   .visual {
+    box-sizing: border-box;
     width: calc(100% + var(--devboards-padding) * 2);
+    max-width: 100vw;
     margin-left: calc(var(--devboards-padding) * -1);
     margin-right: calc(var(--devboards-padding) * -1);
   }


### PR DESCRIPTION
## Summary by Sourcery

Extend GitHub contributors data generation wait time and adjust DevBoards layout styling.

Bug Fixes:
- Prevent DevBoards visual section from overflowing the viewport by constraining width and adjusting box sizing.

Enhancements:
- Increase the maximum wait duration and adjust polling interval when fetching GitHub contributors data in the generation script.

CI:
- Update the GitHub API data generation script timing behavior used in CI workflows.