### PR TITLE
fix: update VS Code marketplace link

### DIFF
--- a/src/components/Dashboard/mdx/stats_detail.de.md
+++ b/src/components/Dashboard/mdx/stats_detail.de.md
@@ -132,7 +132,7 @@ Die folgenden Erläuterungen entsprechen den sechs Kernkennzahlen der offizielle
 ### Distributionskanäle der RuyiSDK-VS-Code-Erweiterung
 
 - [Open VSX](https://open-vsx.org/extension/RuyiSDK/ruyisdk-vscode-extension): für VSCodium.
-- [Visual Studio Marketplace](https://marketplace.visualstudio.com/manage/publishers/RuyiSDK): für VS Code.
+- [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=RuyiSDK.ruyisdk-vscode-extension): für VS Code.
 - [GitHub Releases](https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/): manueller Download und Installation der VSIX-Datei.
 - [ISCAS-Spiegelserver](https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/): manueller Download und Installation der VSIX-Datei.
 

--- a/src/components/Dashboard/mdx/stats_detail.en.md
+++ b/src/components/Dashboard/mdx/stats_detail.en.md
@@ -132,7 +132,7 @@ The following explanations correspond to the six core metrics on the official st
 ### RuyiSDK VS Code Extension Distribution Channels
 
 - [Open VSX](https://open-vsx.org/extension/RuyiSDK/ruyisdk-vscode-extension): for VSCodium.
-- [Visual Studio Marketplace](https://marketplace.visualstudio.com/manage/publishers/RuyiSDK): for VS Code.
+- [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=RuyiSDK.ruyisdk-vscode-extension): for VS Code.
 - [GitHub Releases](https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/): manual VSIX download and installation.
 - [ISCAS mirrors](https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/): manual VSIX download and installation.
 

--- a/src/components/Dashboard/mdx/stats_detail.zh-Hans.md
+++ b/src/components/Dashboard/mdx/stats_detail.zh-Hans.md
@@ -134,7 +134,7 @@
 ### RuyiSDK VS Code Extension 分发渠道
 
 - [Open VSX](https://open-vsx.org/extension/RuyiSDK/ruyisdk-vscode-extension)：适用于 VSCodium。  
-- [Visual Studio Marketplace](https://marketplace.visualstudio.com/manage/publishers/RuyiSDK)：适用于 VS Code。  
+- [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=RuyiSDK.ruyisdk-vscode-extension)：适用于 VS Code。
 - [GitHub Releases](https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/)：手动下载 VSIX 安装。  
 - [ISCAS 镜像源](https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/)：手动下载 VSIX 安装。
 


### PR DESCRIPTION
## Summary

This PR updates the Visual Studio Marketplace link on the dashboard page.

The previous link pointed to the publisher management page, which is only accessible to administrators. It has been replaced with the public extension page.

## Changes

- Updated the VS Code Marketplace link in the dashboard content.
- Applied the change to the English, Chinese, and German dashboard mdx files.
- No unrelated content was changed.

## Summary by Sourcery

Update dashboard documentation links to point to the public Visual Studio Marketplace page for the VS Code extension.

Bug Fixes:
- Correct the Visual Studio Marketplace URL in the dashboard to use the public extension page instead of the publisher management page.

Documentation:
- Align the Visual Studio Marketplace link across English, Chinese, and German dashboard MDX files to the correct public extension page.