### PR TITLE
fix: render spec card titles on riscv specs page

### DIFF
--- a/src/components/RiscvSpecPage/index.jsx
+++ b/src/components/RiscvSpecPage/index.jsx
@@ -164,12 +164,15 @@ function AudienceGuide() {
 }
 
 function SpecCard({ spec }) {
+  const title = spec.title || spec.titleZh;
+  const subtitle = spec.subtitle || spec.titleEn;
+
   return (
     <article className={styles.card}>
       <div className={styles.cardHeader}>
         <div>
-          <h3 className={styles.cardTitle}>{spec.titleZh}</h3>
-          <p className={styles.cardSubtitle}>{spec.titleEn}</p>
+          <h3 className={styles.cardTitle}>{title}</h3>
+          <p className={styles.cardSubtitle}>{subtitle}</p>
         </div>
         <span className={styles.version}>{spec.version}</span>
       </div>


### PR DESCRIPTION
## Summary

This PR fixes the missing titles in spec cards on the `/riscv-specs` page.

Previously, the spec card header rendered an empty title area while the version, description, target audience, and download button were still displayed. This update makes the card render the proper title and subtitle fields with fallback support for existing data fields.

## Changes

- Updated the spec card title rendering logic.
- Rendered `title` / `subtitle` with fallback to legacy fields.
- Verified that Chinese and English spec cards have no missing titles.
- Kept the guide badge section unchanged.

## Verification

- Ran `pnpm.cmd build` successfully.
- Checked generated files:
  - `build/riscv-specs/index.html`
  - `build/en/riscv-specs/index.html`
- Confirmed there are 26 `<h3>` titles and 0 empty titles in both builds.

## Summary by Sourcery

Fix RISC-V spec cards to display titles correctly and update documentation links for the VS Code extension distribution channels.

Bug Fixes:
- Ensure RISC-V spec cards render non-empty titles and subtitles using primary and legacy spec fields.
- Correct the Visual Studio Marketplace URL for the RuyiSDK VS Code extension in all localized stats detail pages.

Documentation:
- Update English, German, and Simplified Chinese stats detail docs to point to the correct Visual Studio Marketplace item URL for the RuyiSDK VS Code extension.