### PR TITLE
Remove the watermark and ruyisdk logo from the document page.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,7 +79,7 @@ const config = {
       image: "img/ruyi-logo-720.jpg",
       navbar: {
         title: "RuyiSDK",
-        hideOnScroll: true,
+        hideOnScroll: false,
         logo: {
           alt: "RuyiSDK Logo",
           src: "img/ruyi-logo-720.svg",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,7 +79,7 @@ const config = {
       image: "img/ruyi-logo-720.jpg",
       navbar: {
         title: "RuyiSDK",
-        hideOnScroll: false,
+        hideOnScroll: true,
         logo: {
           alt: "RuyiSDK Logo",
           src: "img/ruyi-logo-720.svg",

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -351,15 +351,6 @@ h6.anchor .hash-link,
   color: var(--ifm-color-primary);
 }
 
-/* Dark theme adjustments for anchor links */
-html[data-theme="dark"] .hash-link {
-  color: var(--ifm-color-emphasis-400);
-  
-  &:hover {
-    background-color: var(--ifm-color-emphasis-200);
-    color: var(--ifm-color-primary);
-  }
-}
 
 @import "./docs-sidebar.css";
 @import "./news-skeleton.css";

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -351,6 +351,15 @@ h6.anchor .hash-link,
   color: var(--ifm-color-primary);
 }
 
+/* Dark theme adjustments for anchor links */
+html[data-theme="dark"] .hash-link {
+  color: var(--ifm-color-emphasis-400);
+
+  &:hover {
+    background-color: var(--ifm-color-emphasis-200);
+    color: var(--ifm-color-primary);
+  }
+}
 
 @import "./docs-sidebar.css";
 @import "./news-skeleton.css";

--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -1,18 +1,23 @@
 :root {
     --docs-sidebar-font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-    --docs-sidebar-text-color: #444;
-    --docs-sidebar-text-color-hover: #000000;
-    --docs-sidebar-text-color-active: #0a2c7e;
-    --docs-sidebar-bg-hover: rgba(0, 0, 0, 0.02);
-    --docs-sidebar-font-size-l1: 18px;
-    --docs-sidebar-font-size-l2: 16px;
+    --docs-sidebar-text-color: #4b5563;
+    --docs-sidebar-text-color-hover: #111827;
+    --docs-sidebar-text-color-active: #0f172a;
+    --docs-sidebar-bg-hover: rgba(15, 23, 42, 0.05);
+    --docs-sidebar-bg-active: rgba(15, 23, 42, 0.08);
+    --docs-sidebar-bg: transparent;
+    --docs-sidebar-border: transparent;
+    --docs-sidebar-shadow: none;
+    --docs-sidebar-radius: 6px;
+    --docs-sidebar-font-size-l1: 14px;
+    --docs-sidebar-font-size-l2: 14px;
     --docs-sidebar-font-size-l3: 14px;
-    --docs-sidebar-padding-y-l1: 0.375rem;
+    --docs-sidebar-padding-y-l1: 0.25rem;
     --docs-sidebar-padding-y-l2: 0.25rem;
     --docs-sidebar-padding-y-l3: 0.25rem;
-    --docs-sidebar-padding-x-l1: 0.75rem;
-    --docs-sidebar-padding-x-l2: 1.5rem;
-    --docs-sidebar-padding-x-l3: 2.25rem;
+    --docs-sidebar-padding-x-l1: 0.5rem;
+    --docs-sidebar-padding-x-l2: 0.5rem;
+    --docs-sidebar-padding-x-l3: 0.5rem;
 }
 
 aside.theme-doc-sidebar-container,
@@ -20,14 +25,24 @@ aside.theme-doc-sidebar-container,
     border-right: none !important;
 }
 
+.theme-doc-sidebar-container {
+    border: 1px solid var(--docs-sidebar-border) !important;
+    border-radius: var(--docs-sidebar-radius) !important;
+    background: var(--docs-sidebar-bg) !important;
+    box-shadow: var(--docs-sidebar-shadow);
+    padding: 0 !important;
+}
+
 .theme-doc-sidebar-container .menu__list-item {
     background-color: transparent !important;
+    margin: 0.35rem 0;
 }
 
 .theme-doc-sidebar-container .menu__link {
     font-family: var(--docs-sidebar-font-family) !important;
     background-color: transparent !important;
     color: var(--docs-sidebar-text-color) !important;
+    border-radius: var(--docs-sidebar-radius);
     transition: color 0.2s ease, background-color 0.2s ease !important;
 }
 
@@ -39,7 +54,9 @@ aside.theme-doc-sidebar-container,
 .theme-doc-sidebar-container .menu__link--active,
 .theme-doc-sidebar-container .menu__link--active:hover {
     color: var(--docs-sidebar-text-color-active) !important;
-    background-color: color-mix(in srgb, var(--docs-sidebar-text-color-active) 8%, transparent) !important;
+    background-color: var(--docs-sidebar-bg-active) !important;
+    box-shadow: none;
+    font-weight: 600 !important;
 }
 
 /* Category rows and leaf links share the same clickable row style */
@@ -51,6 +68,11 @@ aside.theme-doc-sidebar-container,
     font-family: var(--docs-sidebar-font-family) !important;
     background-color: transparent !important;
     color: var(--docs-sidebar-text-color) !important;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible {
+    position: relative;
 }
 
 /* Level-specific typography and spacing */
@@ -82,15 +104,15 @@ aside.theme-doc-sidebar-container,
 
 /* Category nesting guides */
 .theme-doc-sidebar-item-category-level-1 > .menu__list {
-    margin-left: 0.5rem;
-    border-left: 1px solid rgba(0, 0, 0, 0.08);
+    margin-left: 1rem;
+    border-left: 1px solid #e5e7eb;
     padding-left: 0.75rem;
 }
 
 .theme-doc-sidebar-item-category-level-2 > .menu__list {
-    margin-left: 0.5rem;
-    border-left: 1px solid rgba(0, 0, 0, 0.06);
-    padding-left: 0.5rem;
+    margin-left: 1rem;
+    border-left: 1px solid #e5e7eb;
+    padding-left: 0.75rem;
 }
 
 /* Hide native carets but keep button for accessibility/click handling */
@@ -106,6 +128,41 @@ aside.theme-doc-sidebar-container,
     padding: 0 !important;
     border: none !important;
     background: transparent !important;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link--sublist::after,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link--sublist::after {
+    content: "";
+    position: absolute;
+    right: 0.7rem;
+    top: 50%;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-right: 1.2px solid currentColor;
+    border-bottom: 1.2px solid currentColor;
+    transform: translateY(-58%) rotate(-45deg);
+    opacity: 0.75;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.theme-doc-sidebar-item-category-level-1:not(.menu__list-item--collapsed) > .menu__list-item-collapsible > .menu__link--sublist::after,
+.theme-doc-sidebar-item-category-level-2:not(.menu__list-item--collapsed) > .menu__list-item-collapsible > .menu__link--sublist::after {
+    transform: translateY(-62%) rotate(45deg);
+    opacity: 1;
+}
+
+.theme-doc-sidebar-container .menu__list-item-collapsible > .menu__link--sublist {
+    padding-right: 1.6rem !important;
+}
+
+@media (max-width: 996px) {
+    .theme-doc-sidebar-container {
+        border-radius: 0 !important;
+        border-left: 0 !important;
+        border-right: 0 !important;
+        box-shadow: none !important;
+        backdrop-filter: none;
+    }
 }
 
 /* Font styles - Only apply to docs pages */

--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -1,86 +1,103 @@
-
-aside.theme-doc-sidebar-container {
-    border-right: none !important;
+:root {
+    --docs-sidebar-font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --docs-sidebar-text-color: #444;
+    --docs-sidebar-text-color-hover: #000000;
+    --docs-sidebar-text-color-active: #0a2c7e;
+    --docs-sidebar-bg-hover: rgba(0, 0, 0, 0.02);
+    --docs-sidebar-font-size-l1: 18px;
+    --docs-sidebar-font-size-l2: 16px;
+    --docs-sidebar-font-size-l3: 14px;
+    --docs-sidebar-padding-y-l1: 0.375rem;
+    --docs-sidebar-padding-y-l2: 0.25rem;
+    --docs-sidebar-padding-y-l3: 0.25rem;
+    --docs-sidebar-padding-x-l1: 0.75rem;
+    --docs-sidebar-padding-x-l2: 1.5rem;
+    --docs-sidebar-padding-x-l3: 2.25rem;
 }
 
+aside.theme-doc-sidebar-container,
 .theme-doc-sidebar-container {
     border-right: none !important;
 }
 
-/* Menu items with sublists should not be bold
-/ Level 1 categories use 14px, level 2+ categories use 14px */
-.theme-doc-sidebar-item-category-level-1 .menu__link--sublist {
-    font-weight: normal !important;
-    font-size: 14px !important;
-}
-
-.theme-doc-sidebar-item-category-level-2 .menu__link--sublist,
-.theme-doc-sidebar-item-category-level-3 .menu__link--sublist {
-    font-weight: normal !important;
-    font-size: 14px !important;
-}
-
-.theme-doc-sidebar-item-link-level-1 > :is(a, button) {
+.theme-doc-sidebar-container .menu__list-item {
     background-color: transparent !important;
-    font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-    font-size: 14px !important;
-    color: #666666 !important;
 }
 
-.theme-doc-sidebar-item-link-level-2 > :is(a, button) {
+.theme-doc-sidebar-container .menu__link {
+    font-family: var(--docs-sidebar-font-family) !important;
     background-color: transparent !important;
-    font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-    font-size: 14px !important;
-    color: #666666 !important;
+    color: var(--docs-sidebar-text-color) !important;
+    transition: color 0.2s ease, background-color 0.2s ease !important;
 }
 
+.theme-doc-sidebar-container .menu__link:hover {
+    color: var(--docs-sidebar-text-color-hover) !important;
+    background-color: var(--docs-sidebar-bg-hover) !important;
+}
+
+.theme-doc-sidebar-container .menu__link--active,
+.theme-doc-sidebar-container .menu__link--active:hover {
+    color: var(--docs-sidebar-text-color-active) !important;
+    background-color: color-mix(in srgb, var(--docs-sidebar-text-color-active) 8%, transparent) !important;
+}
+
+/* Category rows and leaf links share the same clickable row style */
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > :is(a, button),
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > :is(a, button),
+.theme-doc-sidebar-item-link-level-1 > :is(a, button),
+.theme-doc-sidebar-item-link-level-2 > :is(a, button),
 .theme-doc-sidebar-item-link-level-3 > :is(a, button) {
+    font-family: var(--docs-sidebar-font-family) !important;
     background-color: transparent !important;
-    font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-    font-size: 14px !important;
-    color: #666666 !important;
+    color: var(--docs-sidebar-text-color) !important;
 }
 
-/* Category items (both level 1 and level 2) */
-.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > :is(a, button) {
-    background-color: transparent !important;
-    font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-    font-size: 14px !important;
-    color: #666666 !important;
+/* Level-specific typography and spacing */
+.theme-doc-sidebar-item-link-level-1 > .menu__link,
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link--sublist {
+    font-weight: 500 !important;
+    font-size: var(--docs-sidebar-font-size-l1) !important;
+    padding-left: var(--docs-sidebar-padding-x-l1) !important;
+    padding-top: var(--docs-sidebar-padding-y-l1) !important;
+    padding-bottom: var(--docs-sidebar-padding-y-l1) !important;
 }
 
-.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > :is(a, button) {
-    background-color: transparent !important;
-    font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-    font-size: 14px !important;
-    color: #666666 !important;
+.theme-doc-sidebar-item-link-level-2 > .menu__link,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link--sublist {
+    font-weight: 400 !important;
+    font-size: var(--docs-sidebar-font-size-l2) !important;
+    padding-left: var(--docs-sidebar-padding-x-l2) !important;
+    padding-top: var(--docs-sidebar-padding-y-l2) !important;
+    padding-bottom: var(--docs-sidebar-padding-y-l2) !important;
 }
 
-/* Remove all background highlights from sidebar items */
-.menu__list-item {
-    background-color: transparent !important;
+.theme-doc-sidebar-item-link-level-3 > .menu__link {
+    font-weight: 400 !important;
+    font-size: var(--docs-sidebar-font-size-l3) !important;
+    padding-left: var(--docs-sidebar-padding-x-l3) !important;
+    padding-top: var(--docs-sidebar-padding-y-l3) !important;
+    padding-bottom: var(--docs-sidebar-padding-y-l3) !important;
 }
 
-.menu__list-item:hover {
-    background-color: transparent !important;
+/* Category nesting guides */
+.theme-doc-sidebar-item-category-level-1 > .menu__list {
+    margin-left: 0.5rem;
+    border-left: 1px solid rgba(0, 0, 0, 0.08);
+    padding-left: 0.75rem;
 }
 
-.menu__list-item--collapsed {
-    background-color: transparent !important;
+.theme-doc-sidebar-item-category-level-2 > .menu__list {
+    margin-left: 0.5rem;
+    border-left: 1px solid rgba(0, 0, 0, 0.06);
+    padding-left: 0.5rem;
 }
 
-
-/* Sidebar menu hierarchical styling */
-.menu__link--sublist {
-    cursor: pointer !important;
-    user-select: none !important;
-}
-
-/* Hide all Docusaurus native arrows visually but keep them functional */
+/* Hide native carets but keep button for accessibility/click handling */
 .menu__caret {
     opacity: 0 !important;
     visibility: hidden !important;
-    pointer-events: none !important;
+    pointer-events: auto !important;
     position: absolute !important;
     width: 0 !important;
     height: 0 !important;
@@ -89,155 +106,6 @@ aside.theme-doc-sidebar-container {
     padding: 0 !important;
     border: none !important;
     background: transparent !important;
-}
-
-/* Hide arrow pseudo-elements */
-.menu__link--sublist-caret:after {
-    display: none !important;
-}
-
-.menu__link--sublist::after {
-    display: none !important;
-}
-
-/* Make entire title area clickable for expand/collapse */
-.menu__link--sublist {
-    cursor: pointer !important;
-    user-select: none !important;
-    position: relative !important;
-}
-
-/* Make collapsible container clickable */
-.menu__list-item-collapsible {
-    cursor: pointer !important;
-
-    .menu__link--sublist {
-        pointer-events: auto !important;
-    }
-}
-
-/* Level 1 - Top level categories (e.g., "Ruyi 包管理器") */
-.theme-doc-sidebar-item-category-level-1 {
-    margin-top: 0.5rem;
-    margin-bottom: 0.25rem;
-
-    .menu__list-item-collapsible {
-        .menu__link--sublist {
-            font-weight: normal !important;
-            font-size: 14px !important;
-            color: #333333 !important;
-            padding-left: 0.75rem !important;
-            padding-top: 0.5rem !important;
-            padding-bottom: 0.5rem !important;
-            border-left: 3px solid transparent !important;
-            transition: all 0.2s ease !important;
-
-            &:hover {
-                color: #000000 !important;
-                background-color: rgba(0, 0, 0, 0.03) !important;
-            }
-        }
-
-        /* Shrink arrow for level 1  */
-        .menu__caret {
-            width: 12px !important;
-            height: 12px !important;
-            min-width: 12px !important;
-            min-height: 12px !important;
-
-            svg {
-                width: 12px !important;
-                height: 12px !important;
-            }
-        }
-    }
-
-    > .menu__list {
-        margin-left: 0.5rem;
-        border-left: 1px solid rgba(0, 0, 0, 0.08);
-        padding-left: 0.75rem;
-    }
-}
-
-/* Level 2 - Second level categories (e.g., "使用案例") */
-.theme-doc-sidebar-item-category-level-2 {
-    margin-top: 0.25rem;
-    margin-bottom: 0.125rem;
-
-    .menu__list-item-collapsible {
-        .menu__link--sublist {
-            font-weight: 500 !important;
-            font-size: 14px !important;
-            color: #555555 !important;
-            padding-left: 0.5rem !important;
-            padding-top: 0.375rem !important;
-            padding-bottom: 0.375rem !important;
-            border-left: 2px solid transparent !important;
-            transition: all 0.2s ease !important;
-
-            &:hover {
-                color: #333333 !important;
-                background-color: rgba(0, 0, 0, 0.02) !important;
-            }
-        }
-    }
-
-    > .menu__list {
-        margin-left: 0.5rem;
-        border-left: 1px solid rgba(0, 0, 0, 0.06);
-        padding-left: 0.5rem;
-    }
-}
-
-/* Level 1 links */
-.theme-doc-sidebar-item-link-level-1 {
-    .menu__link {
-        font-weight: 500 !important;
-        font-size: 15px !important;
-        color: #444444 !important;
-        padding-left: 0.75rem !important;
-        padding-top: 0.375rem !important;
-        padding-bottom: 0.375rem !important;
-
-        &:hover {
-            color: #000000 !important;
-            background-color: rgba(0, 0, 0, 0.02) !important;
-        }
-    }
-}
-
-/* Level 2 links */
-.theme-doc-sidebar-item-link-level-2 {
-    .menu__link {
-        font-weight: 400 !important;
-        font-size: 14px !important;
-        color: #666666 !important;
-        padding-left: 1.5rem !important;
-        padding-top: 0.25rem !important;
-        padding-bottom: 0.25rem !important;
-
-        &:hover {
-            color: #333333 !important;
-            background-color: rgba(0, 0, 0, 0.02) !important;
-        }
-    }
-}
-
-/* Level 3 links */
-.theme-doc-sidebar-item-link-level-3 {
-    .menu__link {
-        font-weight: 400 !important;
-        font-size: 13px !important;
-        color: #777777 !important;
-        padding-left: 2.25rem !important;
-        padding-top: 0.25rem !important;
-        padding-bottom: 0.25rem !important;
-
-        &:hover {
-            color: #444444 !important;
-            background-color: rgba(0, 0, 0, 0.02) !important;
-        }
-    }
 }
 
 /* Font styles - Only apply to docs pages */
@@ -352,26 +220,26 @@ main[class*="docMainContainer"] {
     gap: 32px;
 }
 
-.docs-wrapper aside.theme-doc-sidebar-container { flex: 0 0 220px; }
-.docs-wrapper [class*="docItemCol"] { max-width: 760px; }
-.docs-wrapper .col.col--3 { flex: 0 0 200px; }
+.theme-doc-wrapper aside.theme-doc-sidebar-container { flex: 0 0 220px; }
+.theme-doc-wrapper [class*="docItemCol"] { max-width: 760px; }
+.theme-doc-wrapper .col.col--3 { flex: 0 0 200px; }
 
-.docs-wrapper div[class*="sidebarViewport"] {
+.theme-doc-wrapper div[class*="sidebarViewport"] {
     overflow-y: auto;             /* 保持可滚 */
 }
 
-.docs-wrapper div[class*="sidebarViewport"]::-webkit-scrollbar {
+.theme-doc-wrapper div[class*="sidebarViewport"]::-webkit-scrollbar {
     width: 0;
     height: 0;
 }
 
 /* Firefox */
-.docs-wrapper div[class*="sidebarViewport"] {
+.theme-doc-wrapper div[class*="sidebarViewport"] {
     scrollbar-width: none;
 }
 
-.docs-wrapper div[class*="sidebarViewport"]::-webkit-scrollbar-track,
-.docs-wrapper div[class*="sidebarViewport"]::-webkit-scrollbar-thumb {
+.theme-doc-wrapper div[class*="sidebarViewport"]::-webkit-scrollbar-track,
+.theme-doc-wrapper div[class*="sidebarViewport"]::-webkit-scrollbar-thumb {
     background: transparent;
 }
 

--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -228,7 +228,7 @@ main[class*="docMainContainer"] {
 }
 
 /* Docs right sidebar watermark (separate block below the TOC) */
-/* .theme-doc-toc-desktop {
+.theme-doc-toc-desktop {
     position: relative;
 
     &::after {
@@ -245,4 +245,4 @@ main[class*="docMainContainer"] {
         border-radius: 0.75rem;
         opacity: 0.65;
     }
-} */
+}

--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -1,62 +1,53 @@
 :root {
-    --docs-sidebar-font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-    --docs-sidebar-text-color: #4b5563;
-    --docs-sidebar-text-color-hover: #111827;
-    --docs-sidebar-text-color-active: #0f172a;
-    --docs-sidebar-bg-hover: rgba(15, 23, 42, 0.05);
-    --docs-sidebar-bg-active: rgba(15, 23, 42, 0.08);
-    --docs-sidebar-bg: transparent;
-    --docs-sidebar-border: transparent;
-    --docs-sidebar-shadow: none;
+    --ifm-font-family-base: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --ifm-heading-font-family: var(--ifm-font-family-base);
+    --ifm-heading-color: #171717;
+    --ifm-font-color-base: #171717;
+    --ifm-menu-color: #4b5563;
+    --ifm-menu-color-active: #0f172a;
+    --ifm-menu-color-background-hover: rgba(15, 23, 42, 0.05);
+    --ifm-menu-color-background-active: rgba(15, 23, 42, 0.08);
+    --ifm-menu-link-padding-vertical: 0.25rem;
+    --ifm-menu-link-padding-horizontal: 0.5rem;
+    --ifm-menu-link-sublist-icon-filter: none;
+    --ifm-menu-link-sublist-icon-size: 0.65rem;
+    --ifm-line-height-base: 1.7;
+    --ifm-paragraph-margin-bottom: 1rem;
     --docs-sidebar-radius: 6px;
-    --docs-sidebar-font-size-l1: 14px;
-    --docs-sidebar-font-size-l2: 14px;
-    --docs-sidebar-font-size-l3: 14px;
-    --docs-sidebar-padding-y-l1: 0.25rem;
-    --docs-sidebar-padding-y-l2: 0.25rem;
-    --docs-sidebar-padding-y-l3: 0.25rem;
-    --docs-sidebar-padding-x-l1: 0.5rem;
-    --docs-sidebar-padding-x-l2: 0.5rem;
-    --docs-sidebar-padding-x-l3: 0.5rem;
 }
 
 aside.theme-doc-sidebar-container,
 .theme-doc-sidebar-container {
-    border-right: none !important;
+    border-right: none;
 }
 
 .theme-doc-sidebar-container {
-    border: 1px solid var(--docs-sidebar-border) !important;
-    border-radius: var(--docs-sidebar-radius) !important;
-    background: var(--docs-sidebar-bg) !important;
-    box-shadow: var(--docs-sidebar-shadow);
-    padding: 0 !important;
+    border-radius: var(--docs-sidebar-radius);
+    padding: 0;
 }
 
 .theme-doc-sidebar-container .menu__list-item {
-    background-color: transparent !important;
+    background-color: transparent;
     margin: 0.35rem 0;
 }
 
 .theme-doc-sidebar-container .menu__link {
-    font-family: var(--docs-sidebar-font-family) !important;
-    background-color: transparent !important;
-    color: var(--docs-sidebar-text-color) !important;
+    background-color: transparent;
     border-radius: var(--docs-sidebar-radius);
-    transition: color 0.2s ease, background-color 0.2s ease !important;
+    transition: color 0.2s ease, background-color 0.2s ease;
 }
 
 .theme-doc-sidebar-container .menu__link:hover {
-    color: var(--docs-sidebar-text-color-hover) !important;
-    background-color: var(--docs-sidebar-bg-hover) !important;
+    color: var(--ifm-heading-color);
+    background-color: var(--ifm-menu-color-background-hover);
 }
 
 .theme-doc-sidebar-container .menu__link--active,
 .theme-doc-sidebar-container .menu__link--active:hover {
-    color: var(--docs-sidebar-text-color-active) !important;
-    background-color: var(--docs-sidebar-bg-active) !important;
+    color: var(--ifm-menu-color-active);
+    background-color: var(--ifm-menu-color-background-active);
     box-shadow: none;
-    font-weight: 600 !important;
+    font-weight: 600;
 }
 
 /* Category rows and leaf links share the same clickable row style */
@@ -65,9 +56,7 @@ aside.theme-doc-sidebar-container,
 .theme-doc-sidebar-item-link-level-1 > :is(a, button),
 .theme-doc-sidebar-item-link-level-2 > :is(a, button),
 .theme-doc-sidebar-item-link-level-3 > :is(a, button) {
-    font-family: var(--docs-sidebar-font-family) !important;
-    background-color: transparent !important;
-    color: var(--docs-sidebar-text-color) !important;
+    background-color: transparent;
 }
 
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible,
@@ -78,28 +67,19 @@ aside.theme-doc-sidebar-container,
 /* Level-specific typography and spacing */
 .theme-doc-sidebar-item-link-level-1 > .menu__link,
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link--sublist {
-    font-weight: 500 !important;
-    font-size: var(--docs-sidebar-font-size-l1) !important;
-    padding-left: var(--docs-sidebar-padding-x-l1) !important;
-    padding-top: var(--docs-sidebar-padding-y-l1) !important;
-    padding-bottom: var(--docs-sidebar-padding-y-l1) !important;
+    font-weight: 500;
+    font-size: 14px;
 }
 
 .theme-doc-sidebar-item-link-level-2 > .menu__link,
 .theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link--sublist {
-    font-weight: 400 !important;
-    font-size: var(--docs-sidebar-font-size-l2) !important;
-    padding-left: var(--docs-sidebar-padding-x-l2) !important;
-    padding-top: var(--docs-sidebar-padding-y-l2) !important;
-    padding-bottom: var(--docs-sidebar-padding-y-l2) !important;
+    font-weight: 400;
+    font-size: 14px;
 }
 
 .theme-doc-sidebar-item-link-level-3 > .menu__link {
-    font-weight: 400 !important;
-    font-size: var(--docs-sidebar-font-size-l3) !important;
-    padding-left: var(--docs-sidebar-padding-x-l3) !important;
-    padding-top: var(--docs-sidebar-padding-y-l3) !important;
-    padding-bottom: var(--docs-sidebar-padding-y-l3) !important;
+    font-weight: 400;
+    font-size: 14px;
 }
 
 /* Category nesting guides */
@@ -117,17 +97,17 @@ aside.theme-doc-sidebar-container,
 
 /* Hide native carets but keep button for accessibility/click handling */
 .menu__caret {
-    opacity: 0 !important;
-    visibility: hidden !important;
-    pointer-events: auto !important;
-    position: absolute !important;
-    width: 0 !important;
-    height: 0 !important;
-    overflow: hidden !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    border: none !important;
-    background: transparent !important;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: auto;
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
 }
 
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link--sublist::after,
@@ -152,120 +132,53 @@ aside.theme-doc-sidebar-container,
 }
 
 .theme-doc-sidebar-container .menu__list-item-collapsible > .menu__link--sublist {
-    padding-right: 1.6rem !important;
+    padding-right: 1.6rem;
 }
 
 @media (max-width: 996px) {
     .theme-doc-sidebar-container {
-        border-radius: 0 !important;
-        border-left: 0 !important;
-        border-right: 0 !important;
-        box-shadow: none !important;
+        border-radius: 0;
+        border-left: 0;
+        border-right: 0;
+        box-shadow: none;
         backdrop-filter: none;
     }
 }
 
-/* Font styles - Only apply to docs pages */
+/* Use Infima typography variables for docs body */
 .docs-wrapper,
 .theme-doc-wrapper,
 [class*="docMainContainer"],
 main[class*="docMainContainer"] {
-    /* H1 heading styles */
-    h1 {
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        font-size: 36px !important;
-        color: #171717 !important;
-        font-weight: 600 !important;
-        line-height: 1.2 !important;
-        letter-spacing: -0.02em !important;
-    }
+    --ifm-font-size-base: 16px;
+    --ifm-heading-font-weight: 600;
+}
 
-    article h1,
-    .markdown h1,
-    .theme-doc-markdown h1 {
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        font-size: 36px !important;
-        color: #171717 !important;
-        font-weight: 600 !important;
-        line-height: 1.2 !important;
-        letter-spacing: -0.02em !important;
-    }
+.theme-doc-wrapper .theme-doc-markdown h1 {
+    font-size: 36px;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+}
 
-    /* Anchor link styles - heading links */
-    h1 a,
-    h2 a,
-    h3 a,
-    h4 a,
-    h5 a,
-    h6 a,
-    .anchor a,
-    .hash-link {
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        color: #171717 !important;
-        text-decoration: none !important;
-        font-weight: inherit !important;
+.theme-doc-wrapper .theme-doc-markdown h2 {
+    font-size: 24px;
+    line-height: 1.3;
+}
 
-        &:hover {
-            color: #171717 !important;
-            text-decoration: none !important;
-        }
-    }
+.theme-doc-wrapper .theme-doc-markdown h3 {
+    font-size: 20px;
+}
 
-    /* Heading sizes for anchor links */
-    h2,
-    h2 a {
-        font-size: 24px !important;
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        color: #171717 !important;
-        font-weight: 600 !important;
-        line-height: 1.3 !important;
-    }
+.theme-doc-wrapper .theme-doc-markdown h4 {
+    font-size: 18px;
+}
 
-    h3,
-    h3 a {
-        font-size: 20px !important;
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        color: #171717 !important;
-        font-weight: 600 !important;
-    }
+.theme-doc-wrapper .theme-doc-markdown p {
+    margin-top: 1rem;
+}
 
-    h4,
-    h4 a {
-        font-size: 18px !important;
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        color: #171717 !important;
-        font-weight: 600 !important;
-    }
-
-    /* Paragraph and body text styles */
-    p,
-    article p,
-    .markdown p,
-    .theme-doc-markdown p {
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        font-size: 16px !important;
-        color: #171717 !important;
-        line-height: 1.7 !important;
-        margin: 16px 0 0 !important;
-        font-weight: 400 !important;
-    }
-
-    /* First paragraph no top margin */
-    article p:first-of-type,
-    .markdown p:first-of-type,
-    .theme-doc-markdown p:first-of-type {
-        margin-top: 0 !important;
-    }
-
-    /* Body text */
-    article,
-    .markdown,
-    .theme-doc-markdown {
-        font-family: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
-        font-size: 16px !important;
-        color: #171717 !important;
-        line-height: 1.7 !important;
-    }
+.theme-doc-wrapper .theme-doc-markdown p:first-of-type {
+    margin-top: 0;
 }
 
 /* doc css here */

--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -14,6 +14,8 @@
     --ifm-line-height-base: 1.7;
     --ifm-paragraph-margin-bottom: 1rem;
     --docs-sidebar-radius: 6px;
+    /* Sidebar logo row: 0 = no slot; var(--ifm-navbar-height) = Docusaurus default logo row */
+    --docs-sidebar-logo-row-height: 0;
 }
 
 aside.theme-doc-sidebar-container,
@@ -185,9 +187,21 @@ main[class*="docMainContainer"] {
 .docs-wrapper div[class*="docRoot"] {
     max-width: 1400px;
     margin: 0 auto;
-    padding: calc(var(--ifm-navbar-height) + 24px) 32px 80px;
+    padding: 24px 32px 80px;
     display: flex;
     gap: 32px;
+}
+
+/* Release sidebar logo row space (hideOnScroll off: no duplicate logo) */
+@media (min-width: 997px) {
+    .theme-doc-wrapper .theme-doc-sidebar-container {
+        margin-top: calc(-1 * var(--docs-sidebar-logo-row-height));
+    }
+
+    .theme-doc-wrapper .theme-doc-sidebar-container > div > div[class*="sidebar"] {
+        padding-top: var(--docs-sidebar-logo-row-height);
+        min-height: var(--docs-sidebar-logo-row-height);
+    }
 }
 
 .theme-doc-wrapper aside.theme-doc-sidebar-container { flex: 0 0 220px; }
@@ -214,7 +228,7 @@ main[class*="docMainContainer"] {
 }
 
 /* Docs right sidebar watermark (separate block below the TOC) */
-.theme-doc-toc-desktop {
+/* .theme-doc-toc-desktop {
     position: relative;
 
     &::after {
@@ -231,4 +245,4 @@ main[class*="docMainContainer"] {
         border-radius: 0.75rem;
         opacity: 0.65;
     }
-}
+} */


### PR DESCRIPTION
## Summary by Sourcery

Refine the documentation layout and sidebar styling while removing branding overlays from the docs pages.

Enhancements:
- Rework docs sidebar styling and typography using shared Infima/CSS variables for consistent fonts, colors, and hierarchy across headings and body text.
- Adjust docs layout and sidebar viewport styles to better align the main content width and scrolling behavior.
- Remove the right sidebar watermark block and associated pseudo-element styling to eliminate watermark visuals on docs pages.
- Simplify anchor link styling by dropping dark-theme-specific overrides in favor of default theme behavior.
- Disable navbar hide-on-scroll to keep the main logo visible while coordinating sidebar spacing to avoid duplicate logo rows.