### PR TITLE
pages(index): fix index font broken caused by #507

### DIFF
--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -1,4 +1,5 @@
-:root {
+.docs-wrapper,
+.theme-doc-wrapper {
     --ifm-font-family-base: Geist, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
     --ifm-heading-font-family: var(--ifm-font-family-base);
     --ifm-heading-color: #171717;
@@ -98,7 +99,7 @@ aside.theme-doc-sidebar-container,
 }
 
 /* Hide native carets but keep button for accessibility/click handling */
-.menu__caret {
+.theme-doc-sidebar-container .menu__caret {
     opacity: 0;
     visibility: hidden;
     pointer-events: auto;


### PR DESCRIPTION
## Summary by Sourcery

Scope CSS variables for documentation font settings to docs wrapper elements and constrain sidebar caret hiding styles to the docs sidebar container.

Enhancements:
- Limit base font CSS variables to documentation wrapper containers instead of the global root.
- Restrict the caret hiding rule to menu carets within the documentation sidebar container.