### PR TITLE
pages(docs): fix li, ol and ul

### DIFF
--- a/src/css/docs-sidebar.css
+++ b/src/css/docs-sidebar.css
@@ -184,6 +184,29 @@ main[class*="docMainContainer"] {
     margin-top: 0;
 }
 
+.docs-wrapper .theme-doc-markdown ul,
+.docs-wrapper .theme-doc-markdown ol,
+.theme-doc-wrapper .theme-doc-markdown ul,
+.theme-doc-wrapper .theme-doc-markdown ol {
+    margin: 0 0 1rem;
+    padding-left: 1.25rem;
+}
+
+.docs-wrapper .theme-doc-markdown ul,
+.theme-doc-wrapper .theme-doc-markdown ul {
+    list-style-type: disc;
+}
+
+.docs-wrapper .theme-doc-markdown ol,
+.theme-doc-wrapper .theme-doc-markdown ol {
+    list-style-type: decimal;
+}
+
+.docs-wrapper .theme-doc-markdown li,
+.theme-doc-wrapper .theme-doc-markdown li {
+    margin-bottom: 0.35rem;
+}
+
 /* doc css here */
 .docs-wrapper div[class*="docRoot"] {
     max-width: 1400px;


### PR DESCRIPTION
## Summary by Sourcery

Standardize list styling in docs markdown pages to ensure consistent spacing and bullet/number appearance.

Enhancements:
- Define consistent margins and left padding for ordered and unordered lists in documentation markdown layouts.
- Set explicit bullet and numbering styles for unordered and ordered lists in docs content.
- Adjust list item spacing in documentation pages for improved readability.