### PR TITLE
docs(CodeBlock): fix code copy on downloads page

### DIFF
--- a/src/components/About/MarkdownCard/styles.module.css
+++ b/src/components/About/MarkdownCard/styles.module.css
@@ -94,6 +94,13 @@
   padding: 0.1rem 0.3rem;
 }
 
+.markdown pre code {
+  background: transparent;
+  border-radius: 0;
+  font-size: inherit;
+  padding: 0;
+}
+
 .markdown blockquote {
   margin: 1rem 0;
   padding: 0.8rem 1rem;

--- a/src/components/About/MarkdownCard/styles.module.css
+++ b/src/components/About/MarkdownCard/styles.module.css
@@ -94,7 +94,7 @@
   padding: 0.1rem 0.3rem;
 }
 
-.markdown pre code {
+.markdown :not(pre) > code {
   background: transparent;
   border-radius: 0;
   font-size: inherit;

--- a/src/components/Docs/CodeBlock/CodeBlock.jsx
+++ b/src/components/Docs/CodeBlock/CodeBlock.jsx
@@ -332,7 +332,7 @@ const CodeBlock = ({
                     const btnPadding = isMobile ? '2px' : '3px';
                     
                     copyBtn.style.cssText = `
-                        position: fixed;
+                        position: absolute;
                         transform: translateY(-50%);
                         background: ${isDark ? 'rgba(38, 38, 38, 0.95)' : 'rgba(255, 255, 255, 0.95)'};
                         border: 1px solid ${isDark ? 'rgba(82, 82, 82, 0.8)' : 'rgba(203, 213, 225, 0.8)'};
@@ -362,11 +362,8 @@ const CodeBlock = ({
                     `;
 
                     const updateCopyButtonPosition = () => {
-                        const scrollRect = scrollElement.getBoundingClientRect();
-                        const lineRect = line.getBoundingClientRect();
-
-                        copyBtn.style.left = `${scrollRect.right - btnSize - btnRight}px`;
-                        copyBtn.style.top = `${lineRect.top + lineRect.height / 2}px`;
+                        copyBtn.style.left = `${scrollElement.scrollLeft + scrollElement.clientWidth - btnSize - btnRight}px`;
+                        copyBtn.style.top = '50%';
                     };
 
                     updateCopyButtonPosition();

--- a/src/components/Docs/LatestReleases/ArchSelector.jsx
+++ b/src/components/Docs/LatestReleases/ArchSelector.jsx
@@ -91,13 +91,13 @@ export default function ArchSelector({ language = 'zh' }) {
           {() => (
             filename ? (
               <>
-                <CodeBlock lang="bash" code={`${currentTranslations.chmodCommand}${filename}`} />
-                <CodeBlock lang="bash" code={`${currentTranslations.sudoCpCommand}${filename} ${currentTranslations.ruyiPath}`} />
+                <CodeBlock lang="bash" hasInput input="1" code={`${currentTranslations.chmodCommand}${filename}`} />
+                <CodeBlock lang="bash" hasInput input="1" code={`${currentTranslations.sudoCpCommand}${filename} ${currentTranslations.ruyiPath}`} />
               </>
             ) : (
               <>
-                <CodeBlock lang="bash" code={`$ chmod +x ./ruyi`} />
-                <CodeBlock lang="bash" code={`$ sudo cp -v ruyi /usr/local/bin/ruyi`} />
+                <CodeBlock lang="bash" hasInput input="1" code={`$ chmod +x ./ruyi`} />
+                <CodeBlock lang="bash" hasInput input="1" code={`$ sudo cp -v ruyi /usr/local/bin/ruyi`} />
               </>
             )
           )}

--- a/src/components/Docs/LatestReleases/index.js
+++ b/src/components/Docs/LatestReleases/index.js
@@ -50,7 +50,7 @@ export function DownloadRuyi({ arch }) {
   if (!data) {
     return (
       <BrowserOnly fallback={<pre><code>$ wget </code></pre>}>
-        {() => <CodeBlock lang="bash" code={`$ wget`} />}
+        {() => <CodeBlock lang="bash" hasInput input="1" code={`$ wget`} />}
       </BrowserOnly>
     );
   }
@@ -59,7 +59,7 @@ export function DownloadRuyi({ arch }) {
 
   return (
     <BrowserOnly fallback={<pre><code>{`$ wget ${link || ''}`}</code></pre>}>
-      {() => <CodeBlock lang="bash" code={`$ wget ${link}`} />}
+      {() => <CodeBlock lang="bash" hasInput input="1" code={`$ wget ${link}`} />}
     </BrowserOnly>
   );
 }
@@ -81,24 +81,24 @@ export function ChmodCommand({ arch }) {
   const data = useReleaseData();
 
   if (!data) {
-    return <CodeBlock lang="bash" code={`$ chmod +x ./ruyi`} />;
+    return <CodeBlock lang="bash" hasInput input="1" code={`$ chmod +x ./ruyi`} />;
   }
 
   const link = data.channels.stable.download_urls[`linux/${arch}`]?.[1];
   const fileName = extractFileName(link);
 
-  return <CodeBlock lang="bash" code={`$ chmod +x ./${fileName || 'ruyi'}`} />;
+  return <CodeBlock lang="bash" hasInput input="1" code={`$ chmod +x ./${fileName || 'ruyi'}`} />;
 }
 
 export function CpCommand({ arch }) {
   const data = useReleaseData();
 
   if (!data) {
-    return <CodeBlock lang="bash" code={`$ sudo cp -v ./ruyi /usr/local/bin/ruyi`} />;
+    return <CodeBlock lang="bash" hasInput input="1" code={`$ sudo cp -v ./ruyi /usr/local/bin/ruyi`} />;
   }
 
   const link = data.channels.stable.download_urls[`linux/${arch}`]?.[1];
   const fileName = extractFileName(link);
 
-  return <CodeBlock lang="bash" code={`$ sudo cp -v ./${fileName || 'ruyi'} /usr/local/bin/ruyi`} />;
+  return <CodeBlock lang="bash" hasInput input="1" code={`$ sudo cp -v ./${fileName || 'ruyi'} /usr/local/bin/ruyi`} />;
 }


### PR DESCRIPTION
但是如果有滚动条的话，这个按钮现在不会贴边，而是跟着滚动。

另外 ``.markdown pre code {`` 的作用存疑

## Summary by Sourcery

Adjust code block copy button positioning in docs and refine markdown code styling.

Enhancements:
- Update docs code block copy button to use absolute positioning within the scroll container so it stays aligned when horizontally scrolled.
- Normalize markdown code styling in About markdown cards by removing extra background, radius, and padding from inline code blocks.