### PR TITLE
pages(downloads): fix markdown codeblock support

### DIFF
--- a/src/components/About/MarkdownCard/styles.module.css
+++ b/src/components/About/MarkdownCard/styles.module.css
@@ -94,7 +94,7 @@
   padding: 0.1rem 0.3rem;
 }
 
-.markdown :not(pre) > code {
+.markdown pre > code {
   background: transparent;
   border-radius: 0;
   font-size: inherit;

--- a/src/components/Docs/CodeBlock/CodeBlock.jsx
+++ b/src/components/Docs/CodeBlock/CodeBlock.jsx
@@ -332,7 +332,7 @@ const CodeBlock = ({
                     const btnPadding = isMobile ? '2px' : '3px';
                     
                     copyBtn.style.cssText = `
-                        position: absolute;
+                        position: fixed;
                         transform: translateY(-50%);
                         background: ${isDark ? 'rgba(38, 38, 38, 0.95)' : 'rgba(255, 255, 255, 0.95)'};
                         border: 1px solid ${isDark ? 'rgba(82, 82, 82, 0.8)' : 'rgba(203, 213, 225, 0.8)'};
@@ -362,8 +362,11 @@ const CodeBlock = ({
                     `;
 
                     const updateCopyButtonPosition = () => {
-                        copyBtn.style.left = `${scrollElement.scrollLeft + scrollElement.clientWidth - btnSize - btnRight}px`;
-                        copyBtn.style.top = '50%';
+                        const scrollRect = scrollElement.getBoundingClientRect();
+                        const lineRect = line.getBoundingClientRect();
+
+                        copyBtn.style.left = `${scrollRect.right - btnSize - btnRight}px`;
+                        copyBtn.style.top = `${lineRect.top + lineRect.height / 2}px`;
                     };
 
                     updateCopyButtonPosition();
@@ -504,7 +507,14 @@ const CodeBlock = ({
                         copyBtn.addEventListener('click', handleCopy);
                     }
                     
-                    line.appendChild(copyBtn);
+                    document.body.appendChild(copyBtn);
+                    cleanupFns.push(() => {
+                        try {
+                            copyBtn.remove();
+                        } catch {
+                            // no-op
+                        }
+                    });
                 } else {
                     // Remove copy button if line is not highlighted
                     const existingBtn = line.querySelector('.line-copy-button');

--- a/src/components/Downloads/DownloadInstallScript.jsx
+++ b/src/components/Downloads/DownloadInstallScript.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import MarkdownCard from '@site/src/components/About/MarkdownCard';
+import CodeBlock from '@theme/CodeBlock';
 
 import InstallEn from './mdx/install.en.mdx';
 import InstallZhHans from './mdx/install.zh-Hans.mdx';
@@ -14,13 +15,27 @@ function resolveLocalizedContent(contentMap, locale) {
   return contentMap[locale] || contentMap.en;
 }
 
+function PreCodeBlock(props) {
+  const code = React.Children.only(props.children);
+
+  if (!React.isValidElement(code) || code.type !== 'code') {
+    return <pre {...props} />;
+  }
+
+  return <CodeBlock {...code.props} />;
+}
+
+const MDX_COMPONENTS = {
+  pre: PreCodeBlock,
+};
+
 export default function DownloadInstallScript() {
   const { i18n } = useDocusaurusContext();
   const InstallContent = resolveLocalizedContent(INSTALL_CONTENT, i18n?.currentLocale);
 
   return (
     <MarkdownCard className="w-full">
-      <InstallContent />
+      <InstallContent components={MDX_COMPONENTS} />
     </MarkdownCard>
   );
 }

--- a/src/components/Downloads/mdx/install.en.mdx
+++ b/src/components/Downloads/mdx/install.en.mdx
@@ -1,21 +1,13 @@
-import CodeBlock from '@site/src/components/Docs/CodeBlock';
-
 ## Install Ruyi Package Manager
 
 The installer detects your architecture, downloads the latest stable release from the ISCAS mirror first, and installs it to ``~/.local/bin/ruyi``:
 
-<CodeBlock
-  lang="bash"
-  hasInput
-  input="1"
-  code={`$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sh`}
-/>
+```bash input="1"
+$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sh
+```
 
 To install into a system directory, run the script with ``sudo`` and pass an explicit install path:
 
-<CodeBlock
-  lang="bash"
-  hasInput
-  input="1"
-  code={`$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sudo sh -s -- --install-dir /usr/local/bin`}
-/>
+```bash input="1"
+$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sudo sh -s -- --install-dir /usr/local/bin
+```

--- a/src/components/Downloads/mdx/install.zh-Hans.mdx
+++ b/src/components/Downloads/mdx/install.zh-Hans.mdx
@@ -1,21 +1,13 @@
-import CodeBlock from '@site/src/components/Docs/CodeBlock';
-
 ## 安装 Ruyi 包管理器
 
 安装脚本会自动识别系统架构，优先从 ISCAS 镜像下载最新稳定版，并安装到 ``~/.local/bin/ruyi``：
 
-<CodeBlock
-  lang="bash"
-  hasInput
-  input="1"
-  code={`$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sh`}
-/>
+```bash input="1"
+$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sh
+```
 
 如需安装到系统目录，请使用 ``sudo`` 执行脚本并显式指定安装路径：
 
-<CodeBlock
-  lang="bash"
-  hasInput
-  input="1"
-  code={`$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sudo sh -s -- --install-dir /usr/local/bin`}
-/>
+```bash input="1"
+$ curl --proto '=https' --tlsv1.2 -fsSL https://ruyisdk.org/install.sh | sudo sh -s -- --install-dir /usr/local/bin
+```


### PR DESCRIPTION
## Summary by Sourcery

Improve downloads installation markdown rendering and code block behavior.

New Features:
- Render MDX download installation code blocks using the shared CodeBlock component via a custom pre handler.

Bug Fixes:
- Fix markdown downloads pages so bash install snippets render correctly as fenced code blocks with input annotations.

Enhancements:
- Adjust CodeBlock copy button to use fixed positioning with viewport-based coordinates and ensure it is cleaned up when no longer needed.
- Refine markdown code styling so only code within pre blocks loses background and radius styling to better support code fences.