### PR TITLE
pages(docs): fix arch selecte scroll bar

### DIFF
--- a/src/components/Docs/CodeBlock/CodeBlock.jsx
+++ b/src/components/Docs/CodeBlock/CodeBlock.jsx
@@ -15,11 +15,7 @@ const CodeBlock = ({
 }) => {
     const [isHovered, setIsHovered] = useState(false);
     const [currentLang, setCurrentLang] = useState(lang);
-    const codeBlockIdRef = useRef(null);
-
-    if (!codeBlockIdRef.current) {
-        codeBlockIdRef.current = `codeblock-${Math.random().toString(36).slice(2)}`;
-    }
+    const copyButtonsRef = useRef(new Map());
 
     const inputLines = useMemo(() => {
         const lines = new Set();
@@ -249,13 +245,14 @@ const CodeBlock = ({
                 const rightPaddingPx = isMobile ? '56px' : '48px';
                 const leftPaddingPx = isMobile ? '12px' : '20px';
                 const horizontalMargin = isMobile ? '0' : '-20px';
-                const copyButtonSelector = `.line-copy-button[data-code-block-id="${codeBlockIdRef.current}"][data-line-index="${index}"]`;
                 const removeExistingCopyButton = () => {
-                    const existingBtn = line.querySelector('.line-copy-button') || document.body.querySelector(copyButtonSelector);
+                    const existingBtn = line.querySelector('.line-copy-button') || copyButtonsRef.current.get(index);
 
                     if (existingBtn) {
                         existingBtn.remove();
                     }
+
+                    copyButtonsRef.current.delete(index);
                 };
                 
                 // Ensure all lines display as block to preserve line breaks
@@ -329,8 +326,7 @@ const CodeBlock = ({
                     
                     const copyBtn = document.createElement('button');
                     copyBtn.className = 'line-copy-button';
-                    copyBtn.dataset.codeBlockId = codeBlockIdRef.current;
-                    copyBtn.dataset.lineIndex = String(index);
+                    copyButtonsRef.current.set(index, copyBtn);
                     
                     // Larger icon for mobile
                     const iconSize = isMobile ? '12' : '14';
@@ -525,6 +521,9 @@ const CodeBlock = ({
                     cleanupFns.push(() => {
                         try {
                             copyBtn.remove();
+                            if (copyButtonsRef.current.get(index) === copyBtn) {
+                                copyButtonsRef.current.delete(index);
+                            }
                         } catch {
                             // no-op
                         }

--- a/src/components/Docs/CodeBlock/CodeBlock.jsx
+++ b/src/components/Docs/CodeBlock/CodeBlock.jsx
@@ -15,6 +15,11 @@ const CodeBlock = ({
 }) => {
     const [isHovered, setIsHovered] = useState(false);
     const [currentLang, setCurrentLang] = useState(lang);
+    const codeBlockIdRef = useRef(null);
+
+    if (!codeBlockIdRef.current) {
+        codeBlockIdRef.current = `codeblock-${Math.random().toString(36).slice(2)}`;
+    }
 
     const inputLines = useMemo(() => {
         const lines = new Set();
@@ -241,6 +246,14 @@ const CodeBlock = ({
                 const rightPaddingPx = isMobile ? '56px' : '48px';
                 const leftPaddingPx = isMobile ? '12px' : '20px';
                 const horizontalMargin = isMobile ? '0' : '-20px';
+                const copyButtonSelector = `.line-copy-button[data-code-block-id="${codeBlockIdRef.current}"][data-line-index="${index}"]`;
+                const removeExistingCopyButton = () => {
+                    const existingBtn = line.querySelector('.line-copy-button') || document.body.querySelector(copyButtonSelector);
+
+                    if (existingBtn) {
+                        existingBtn.remove();
+                    }
+                };
                 
                 // Ensure all lines display as block to preserve line breaks
                 line.style.display = 'block';
@@ -309,14 +322,12 @@ const CodeBlock = ({
                     line.style.minHeight = '';
                     line.style.lineHeight = 'var(--ifm-pre-line-height)';
                     
-                    // Remove existing copy button if any
-                    const existingBtn = line.querySelector('.line-copy-button');
-                    if (existingBtn) {
-                        existingBtn.remove();
-                    }
+                    removeExistingCopyButton();
                     
                     const copyBtn = document.createElement('button');
                     copyBtn.className = 'line-copy-button';
+                    copyBtn.dataset.codeBlockId = codeBlockIdRef.current;
+                    copyBtn.dataset.lineIndex = String(index);
                     
                     // Larger icon for mobile
                     const iconSize = isMobile ? '12' : '14';
@@ -516,11 +527,7 @@ const CodeBlock = ({
                         }
                     });
                 } else {
-                    // Remove copy button if line is not highlighted
-                    const existingBtn = line.querySelector('.line-copy-button');
-                    if (existingBtn) {
-                        existingBtn.remove();
-                    }
+                    removeExistingCopyButton();
                 }
             });
         }, 100);

--- a/src/components/Docs/CodeBlock/CodeBlock.jsx
+++ b/src/components/Docs/CodeBlock/CodeBlock.jsx
@@ -218,8 +218,11 @@ const CodeBlock = ({
             // First pass: reset styles to measure pure content width (no padding)
             allLines.forEach((line) => {
                 line.style.width = 'auto';
+                line.style.minWidth = '';
                 line.style.display = 'inline-block';
+                line.style.margin = '0';
                 line.style.padding = '0';
+                line.style.boxSizing = '';
             });
             
             // Calculate max content width of ALL lines (pure code content)

--- a/src/components/Downloads/DownloadInstallScript.jsx
+++ b/src/components/Downloads/DownloadInstallScript.jsx
@@ -16,9 +16,13 @@ function resolveLocalizedContent(contentMap, locale) {
 }
 
 function PreCodeBlock(props) {
-  const code = React.Children.only(props.children);
+  const children = React.Children.toArray(props.children);
+  const code = children.find(
+    (child) => React.isValidElement(child)
+      && (child.type === 'code' || child.props?.mdxType === 'code')
+  );
 
-  if (!React.isValidElement(code) || code.type !== 'code') {
+  if (!code) {
     return <pre {...props} />;
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve docs code block rendering and downloads install script code block handling.

Enhancements:
- Ensure per-line copy buttons in docs code blocks are uniquely associated with their code block and cleaned up reliably when toggling highlights.
- Adjust line styling reset logic in docs code blocks to avoid layout side effects when measuring content width.
- Make the downloads install script preformatted block more robust by correctly locating the nested code element among multiple children.