### PR TITLE
pages(downloads): release new download page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,7 +90,7 @@ const config = {
             type: "localeDropdown",
             position: "right",
           },
-          { to: "/download", label: "下载", position: "left" },
+          { to: "/downloads", label: "下载", position: "left" },
           { to: "/news", label: "新闻", position: "left" },
           { to: "/contributors", label: "贡献者", position: "left" },
           { href: "https://ruyisdk.cn", label: "社区", position: "left" },

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -6,6 +6,10 @@ import CodeBlock from '@site/src/components/Docs/CodeBlock';
   <>
 
 ::::tip
+下载页面已经更新，移步[新下载页面](/downloads)获取最新下载信息。
+::::
+
+::::tip
 下载并使用 RuyiSDK，即表示您同意许可条款和[隐私声明](https://ruyisdk.org/docs/legal/privacyPolicy/)。
 ::::
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce and link to a new downloads page while updating navigation to point to it instead of the legacy download page.

Build:
- Update Docusaurus navbar configuration to link the 下载 menu item to /downloads instead of /download.

Documentation:
- Add a tip on the old download page directing users to the new /downloads page for up-to-date download information.