### PR TITLE
ci: deploy website to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy to Cloudflare Pages
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -39,8 +39,11 @@ jobs:
       - name: PNPM Build
         uses: ./.github/workflows/composite_npm_build
 
-      - name: Deploy to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./build --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          # gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 # Build-time generated data (do not commit)
 src/generated/latest_pm.json
 src/pages/Community/generated_contributors.json
-static/api/
 
 # Misc
 .DS_Store


### PR DESCRIPTION
## Summary by Sourcery

Switch website deployment workflow from GitHub Pages to Cloudflare Pages.

CI:
- Update deployment workflow to use Cloudflare Wrangler action and Cloudflare Pages project configuration instead of GitHub Pages.
- Adjust workflow permissions to use read-only repo contents and deployment write access for Cloudflare Pages.